### PR TITLE
Add CI workflows and fix shell recursion warning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,60 @@
+name: codeql-analysis
+
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
+    branches: [main, release/**]
+  schedule:
+    - cron: '25 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  BUNDLE_ARTIFACT: codeql-custom-bundle.tgz
+
+jobs:
+  build-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build CodeQL bundle
+        uses: advanced-security/codeql-bundle-action@v2
+        with:
+          packs: |
+            codeql/cpp-queries@latest
+          output: ${{ env.BUNDLE_ARTIFACT }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUNDLE_ARTIFACT }}
+          path: ${{ env.BUNDLE_ARTIFACT }}
+          retention-days: 5
+
+  codeql-scan:
+    needs: build-bundle
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lang: "c-cpp"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BUNDLE_ARTIFACT }}
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.lang }}
+          tools: ${{ env.BUNDLE_ARTIFACT }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.lang }}"
+          output: sarif

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,39 @@
+name: lint-and-annotate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        linter:
+          - { id: "shellcheck", cmd: "shellcheck -f gcc $(git ls-files '*.sh')" }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install linter runtime deps
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y shellcheck
+      - name: Run ${{ matrix.linter.id }} & feed Reviewdog
+        uses: reviewdog/reviewdog@v0.17.4
+        with:
+          name: ${{ matrix.linter.id }}
+          reporter: github-pr-check
+          filter_mode: diff_context
+          fail_level: error
+          run: ${{ matrix.linter.cmd }}
+          level: warning
+      - name: Emit summary
+        if: always()
+        run: reviewdog -reporter=local -format=rdjson -f .rdjson > $RUNNER_TEMP/rd.json

--- a/sh.c
+++ b/sh.c
@@ -53,8 +53,11 @@ int fork1(void);  // Fork but panics on failure.
 void panic(char*);
 struct cmd *parsecmd(char*);
 
+// Annotate as noreturn so modern compilers know runcmd exits
+static void runcmd(struct cmd *cmd) __attribute__((noreturn));
+
 // Execute cmd.  Never returns.
-void
+static void
 runcmd(struct cmd *cmd)
 {
   int p[2];


### PR DESCRIPTION
## Summary
- add CodeQL scan workflow using a custom bundle
- add Reviewdog lint workflow
- mark `runcmd` as `noreturn` so it builds with modern compilers

## Testing
- `make qemu-nox` *(fails: missing qemu, but build completes)*
- `make clean`
