### PR TITLE
Add initial x86_64 boot path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ endif
 ARCH ?= i686
 CSTD ?= gnu2x
 
+ifeq ($(ARCH),x86_64)
+OBJS += main64.o
+BOOTASM := arch/x64/bootasm64.S
+ENTRYASM := arch/x64/entry64.S
+else
+BOOTASM := bootasm.S
+ENTRYASM := entry.S
+endif
+
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
@@ -110,13 +119,16 @@ xv6memfs.img: bootblock kernelmemfs
 	dd if=bootblock of=xv6memfs.img conv=notrunc
 	dd if=kernelmemfs of=xv6memfs.img seek=1 conv=notrunc
 
-bootblock: bootasm.S bootmain.c
+bootblock: $(BOOTASM) bootmain.c
 	$(CC) $(CFLAGS) -fno-pic -O -nostdinc -I. -c bootmain.c
-	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c bootasm.S
+	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c $(BOOTASM) -o bootasm.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7C00 -o bootblock.o bootasm.o bootmain.o
 	$(OBJDUMP) -S bootblock.o > bootblock.asm
 	$(OBJCOPY) -S -O binary -j .text bootblock.o bootblock
 	./sign.pl bootblock
+entry.o: $(ENTRYASM)
+	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c $(ENTRYASM) -o entry.o
+
 
 entryother: entryother.S
 	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c entryother.S

--- a/arch/x64/bootasm64.S
+++ b/arch/x64/bootasm64.S
@@ -1,0 +1,112 @@
+#include "asm.h"
+#include "memlayout.h"
+#include "mmu.h"
+
+#define CR4_PAE 0x00000020
+
+# Segments for protected mode (32-bit) and long mode (64-bit)
+
+# Helper to build a 64-bit segment descriptor: G=1, L=1, D/B=0
+.macro SEG_ASM64 type base lim
+    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
+    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
+    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
+.endm
+
+.code16
+.globl start
+start:
+    cli
+    xorw %ax,%ax
+    movw %ax,%ds
+    movw %ax,%es
+    movw %ax,%ss
+
+# Enable A20
+seta20.1:
+    inb $0x64,%al
+    testb $0x2,%al
+    jnz seta20.1
+    movb $0xd1,%al
+    outb %al,$0x64
+seta20.2:
+    inb $0x64,%al
+    testb $0x2,%al
+    jnz seta20.2
+    movb $0xdf,%al
+    outb %al,$0x60
+
+    lgdt gdtdesc32
+    movl %cr0,%eax
+    orl $CR0_PE,%eax
+    movl %eax,%cr0
+    ljmp $(1<<3), $prot32
+
+.code32
+prot32:
+    movw $(2<<3), %ax
+    movw %ax,%ds
+    movw %ax,%es
+    movw %ax,%ss
+    movw $0,%ax
+    movw %ax,%fs
+    movw %ax,%gs
+
+    lgdt gdtdesc64
+
+    movl %cr4,%eax
+    orl $CR4_PAE,%eax
+    movl %eax,%cr4
+
+    movl $pml4,%eax
+    movl %eax,%cr3
+
+    movl $0xC0000080,%ecx
+    rdmsr
+    orl $0x00000100,%eax
+    wrmsr
+
+    movl %cr0,%eax
+    orl $(CR0_PE|CR0_PG|CR0_WP),%eax
+    movl %eax,%cr0
+
+    ljmp $(3<<3), $longmode
+
+.code64
+longmode:
+    mov $start,%rsp
+    call bootmain
+1:  jmp 1b
+
+# GDTs
+.p2align 2
+gdt32:
+    SEG_NULLASM
+    SEG_ASM(STA_X|STA_R,0,0xffffffff)
+    SEG_ASM(STA_W,0,0xffffffff)
+
+gdtdesc32:
+    .word (gdtdesc32 - gdt32 - 1)
+    .long gdt32
+
+.p2align 2
+gdt64:
+    SEG_NULLASM
+    SEG_ASM64(STA_X|STA_R,0,0xffffffff)
+    SEG_ASM64(STA_W,0,0xffffffff)
+
+gdtdesc64:
+    .word (gdtdesc64 - gdt64 - 1)
+    .long gdt64
+    .long 0
+
+# Minimal identity-mapped page tables
+.p2align 12
+pml4:
+    .quad pdpt | 0x3
+.p2align 12
+pdpt:
+    .quad pd | 0x3
+.p2align 12
+pd:
+    .quad 0x00000000 | 0x83  # 2MB page

--- a/arch/x64/entry64.S
+++ b/arch/x64/entry64.S
@@ -1,0 +1,43 @@
+#include "asm.h"
+#include "memlayout.h"
+#include "mmu.h"
+#include "param.h"
+
+# Build a 64-bit segment descriptor
+.macro SEG_ASM64 type base lim
+    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
+    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
+    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
+.endm
+
+.p2align 2
+.globl _start
+_start = V2P_WO(entry64)
+
+.globl entry64
+entry64:
+    lgdt gdtdesc
+    movw $(2<<3), %ax
+    movw %ax, %ds
+    movw %ax, %es
+    movw %ax, %ss
+    movw %ax, %fs
+    movw %ax, %gs
+
+    mov $stack64 + KSTACKSIZE, %rsp
+    mov $main64, %rax
+    jmp *%rax
+
+.comm stack64, KSTACKSIZE
+
+# 64-bit GDT for the kernel
+.p2align 2
+gdt:
+    SEG_NULLASM
+    SEG_ASM64(STA_X|STA_R,0,0xffffffff)  # code
+    SEG_ASM64(STA_W,0,0xffffffff)        # data
+
+gdtdesc:
+    .word (gdtdesc - gdt - 1)
+    .long gdt
+    .long 0

--- a/main64.c
+++ b/main64.c
@@ -1,0 +1,7 @@
+#include "types.h"
+
+extern int main(void);
+
+int main64(void) {
+    return main();
+}


### PR DESCRIPTION
## Summary
- introduce bootasm64.S to enter long mode
- add entry64.S with 64-bit GDT setup
- compile the new code when `ARCH=x86_64`
- provide a simple `main64()` wrapper

## Testing
- `make -n bootblock`
- `make ARCH=x86_64 -n bootblock`
- `make ARCH=x86_64 -n entry.o`
