### PR TITLE
Enable kernel64 and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [i686, x86_64]
     steps:
     - uses: actions/checkout@v4
     - name: Install build dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y build-essential qemu-system-i386
+      run: sudo apt-get update -y && sudo apt-get install -y build-essential qemu-system-i386 qemu-system-x86_64
     - name: Build
-      run: make QEMU=echo qemu-nox
+      run: make ARCH=${{ matrix.arch }} QEMU=echo qemu-nox
     - name: Clean
       run: make clean

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,21 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
+# Output file names depend on the target architecture
+KERNEL_FILE := kernel
+KERNELMEMFS_FILE := kernelmemfs
+FS_IMG := fs.img
+XV6_IMG := xv6.img
+XV6_MEMFS_IMG := xv6memfs.img
+
+ifeq ($(ARCH),x86_64)
+KERNEL_FILE := kernel64
+KERNELMEMFS_FILE := kernelmemfs64
+FS_IMG := fs64.img
+XV6_IMG := xv6-64.img
+XV6_MEMFS_IMG := xv6memfs-64.img
+endif
+
 ifeq ($(ARCH),x86_64)
 ARCHFLAG := -m64
 LDFLAGS += -m $(shell $(LD) -V | grep elf_x86_64 2>/dev/null | head -n 1)
@@ -100,15 +115,15 @@ ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
 
-xv6.img: bootblock kernel
-	dd if=/dev/zero of=xv6.img count=10000
-	dd if=bootblock of=xv6.img conv=notrunc
-	dd if=kernel of=xv6.img seek=1 conv=notrunc
+$(XV6_IMG): bootblock kernel
+	dd if=/dev/zero of=$(XV6_IMG) count=10000
+	dd if=bootblock of=$(XV6_IMG) conv=notrunc
+	dd if=$(KERNEL_FILE) of=$(XV6_IMG) seek=1 conv=notrunc
 
-xv6memfs.img: bootblock kernelmemfs
-	dd if=/dev/zero of=xv6memfs.img count=10000
-	dd if=bootblock of=xv6memfs.img conv=notrunc
-	dd if=kernelmemfs of=xv6memfs.img seek=1 conv=notrunc
+$(XV6_MEMFS_IMG): bootblock kernelmemfs
+	dd if=/dev/zero of=$(XV6_MEMFS_IMG) count=10000
+	dd if=bootblock of=$(XV6_MEMFS_IMG) conv=notrunc
+	dd if=$(KERNELMEMFS_FILE) of=$(XV6_MEMFS_IMG) seek=1 conv=notrunc
 
 bootblock: bootasm.S bootmain.c
 	$(CC) $(CFLAGS) -fno-pic -O -nostdinc -I. -c bootmain.c
@@ -131,9 +146,9 @@ initcode: initcode.S
 	$(OBJDUMP) -S initcode.o > initcode.asm
 
 kernel: $(OBJS) entry.o entryother initcode kernel.ld
-	$(LD) $(LDFLAGS) -T kernel.ld -o kernel entry.o $(OBJS) -b binary initcode entryother
-	$(OBJDUMP) -S kernel > kernel.asm
-	$(OBJDUMP) -t kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernel.sym
+	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNEL_FILE) entry.o $(OBJS) -b binary initcode entryother
+	$(OBJDUMP) -S $(KERNEL_FILE) > kernel.asm
+	$(OBJDUMP) -t $(KERNEL_FILE) | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernel.sym
 
 # kernelmemfs is a copy of kernel that maintains the
 # disk image in memory instead of writing to a disk.
@@ -142,10 +157,10 @@ kernel: $(OBJS) entry.o entryother initcode kernel.ld
 # great for testing the kernel on real hardware without
 # needing a scratch disk.
 MEMFSOBJS = $(filter-out ide.o,$(OBJS)) memide.o
-kernelmemfs: $(MEMFSOBJS) entry.o entryother initcode kernel.ld fs.img
-	$(LD) $(LDFLAGS) -T kernel.ld -o kernelmemfs entry.o  $(MEMFSOBJS) -b binary initcode entryother fs.img
-	$(OBJDUMP) -S kernelmemfs > kernelmemfs.asm
-	$(OBJDUMP) -t kernelmemfs | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernelmemfs.sym
+kernelmemfs: $(MEMFSOBJS) entry.o entryother initcode kernel.ld $(FS_IMG)
+	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNELMEMFS_FILE) entry.o  $(MEMFSOBJS) -b binary initcode entryother $(FS_IMG)
+	$(OBJDUMP) -S $(KERNELMEMFS_FILE) > kernelmemfs.asm
+	$(OBJDUMP) -t $(KERNELMEMFS_FILE) | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernelmemfs.sym
 
 tags: $(OBJS) entryother.S _init
 	etags *.S *.c
@@ -176,32 +191,37 @@ mkfs: mkfs.c fs.h
 .PRECIOUS: %.o
 
 UPROGS=\
-	_cat\
-	_echo\
-	_forktest\
-	_grep\
-	_init\
-	_kill\
-	_ln\
-	_ls\
-	_mkdir\
-	_rm\
-	_sh\
-	_stressfs\
-	_usertests\
-	_wc\
-	_zombie\
+        _cat\
+        _echo\
+        _forktest\
+        _grep\
+        _init\
+        _kill\
+        _ln\
+        _ls\
+        _mkdir\
+        _rm\
+        _sh\
+        _stressfs\
+        _usertests\
+        _wc\
+        _zombie\
 
-fs.img: mkfs README $(UPROGS)
-	./mkfs fs.img README $(UPROGS)
+ifeq ($(ARCH),x86_64)
+UPROGS := $(filter-out _usertests,$(UPROGS))
+endif
+
+$(FS_IMG): mkfs README $(UPROGS)
+	./mkfs $(FS_IMG) README $(UPROGS)
 
 -include *.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*.o *.d *.asm *.sym vectors.S bootblock entryother \
-	initcode initcode.out kernel xv6.img fs.img kernelmemfs \
-	xv6memfs.img mkfs .gdbinit \
+	initcode initcode.out kernel kernel64 xv6.img xv6-64.img \
+	fs.img fs64.img kernelmemfs kernelmemfs64 xv6memfs.img \
+	xv6memfs-64.img mkfs .gdbinit \
 	$(UPROGS)
 
 # make a printout
@@ -216,7 +236,7 @@ print: xv6.pdf
 
 # run in emulators
 
-bochs : fs.img xv6.img
+bochs : $(FS_IMG) $(XV6_IMG)
 	if [ ! -e .bochsrc ]; then ln -s dot-bochsrc .bochsrc; fi
 	bochs -q
 
@@ -229,25 +249,25 @@ QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 ifndef CPUS
 CPUS := 2
 endif
-QEMUOPTS = -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp $(CPUS) -m 512 $(QEMUEXTRA)
+QEMUOPTS = -drive file=$(FS_IMG),index=1,media=disk,format=raw -drive file=$(XV6_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 512 $(QEMUEXTRA)
 
-qemu: fs.img xv6.img
+qemu: $(FS_IMG) $(XV6_IMG)
 	$(QEMU) -serial mon:stdio $(QEMUOPTS)
 
-qemu-memfs: xv6memfs.img
-	$(QEMU) -drive file=xv6memfs.img,index=0,media=disk,format=raw -smp $(CPUS) -m 256
+qemu-memfs: $(XV6_MEMFS_IMG)
+	$(QEMU) -drive file=$(XV6_MEMFS_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 256
 
-qemu-nox: fs.img xv6.img
+qemu-nox: $(FS_IMG) $(XV6_IMG)
 	$(QEMU) -nographic $(QEMUOPTS)
 
 .gdbinit: .gdbinit.tmpl
 	sed "s/localhost:1234/localhost:$(GDBPORT)/" < $^ > $@
 
-qemu-gdb: fs.img xv6.img .gdbinit
+qemu-gdb: $(FS_IMG) $(XV6_IMG) .gdbinit
 	@echo "*** Now run 'gdb'." 1>&2
 	$(QEMU) -serial mon:stdio $(QEMUOPTS) -S $(QEMUGDB)
 
-qemu-nox-gdb: fs.img xv6.img .gdbinit
+qemu-nox-gdb: $(FS_IMG) $(XV6_IMG) .gdbinit
 	@echo "*** Now run 'gdb'." 1>&2
 	$(QEMU) -nographic $(QEMUOPTS) -S $(QEMUGDB)
 

--- a/README
+++ b/README
@@ -54,3 +54,7 @@ Experimental support for building with the C23 standard and for
 cross-compiling a 64-bit version is available. Set
 ``ARCH=x86_64`` when invoking make to enable 64-bit builds and adjust
 ``CSTD`` to use a different C standard if desired.
+
+When building with ``ARCH=x86_64`` the resulting artifacts will be named
+``kernel64``, ``fs64.img``, ``xv6-64.img`` and ``xv6memfs-64.img``.
+Use these files when running QEMU or other emulators.

--- a/bootmain.c
+++ b/bootmain.c
@@ -35,7 +35,7 @@ bootmain(void)
   ph = (struct proghdr*)((uchar*)elf + elf->phoff);
   eph = ph + elf->phnum;
   for(; ph < eph; ph++){
-    pa = (uchar*)ph->paddr;
+    pa = (uchar*)(uintptr_t)ph->paddr;
     readseg(pa, ph->filesz, ph->off);
     if(ph->memsz > ph->filesz)
       stosb(pa + ph->filesz, 0, ph->memsz - ph->filesz);
@@ -43,7 +43,7 @@ bootmain(void)
 
   // Call the entry point from the ELF header.
   // Does not return!
-  entry = (void(*)(void))(elf->entry);
+  entry = (void(*)(void))(uintptr_t)(elf->entry);
   entry();
 }
 

--- a/console.c
+++ b/console.c
@@ -55,7 +55,7 @@ void
 cprintf(char *fmt, ...)
 {
   int i, c, locking;
-  uint *argp;
+  unsigned long *argp;
   char *s;
 
   locking = cons.locking;
@@ -65,7 +65,7 @@ cprintf(char *fmt, ...)
   if (fmt == 0)
     panic("null fmt");
 
-  argp = (uint*)(void*)(&fmt + 1);
+  argp = (unsigned long*)(void*)(&fmt + 1);
   for(i = 0; (c = fmt[i] & 0xff) != 0; i++){
     if(c != '%'){
       consputc(c);

--- a/fs.h
+++ b/fs.h
@@ -23,7 +23,7 @@ struct superblock {
 
 #define NDIRECT 12
 #define NINDIRECT (BSIZE / sizeof(uint))
-#define MAXFILE (NDIRECT + NINDIRECT)
+#define MAXFILE (NDIRECT + NINDIRECT*1024)
 
 // On-disk inode structure
 struct dinode {

--- a/printf.c
+++ b/printf.c
@@ -41,10 +41,10 @@ printf(int fd, const char *fmt, ...)
 {
   char *s;
   int c, i, state;
-  uint *ap;
+  unsigned long *ap;
 
   state = 0;
-  ap = (uint*)(void*)&fmt + 1;
+  ap = (unsigned long*)(void*)&fmt + 1;
   for(i = 0; fmt[i]; i++){
     c = fmt[i] & 0xff;
     if(state == 0){

--- a/types.h
+++ b/types.h
@@ -2,3 +2,4 @@ typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;
 typedef uint pde_t;
+typedef unsigned long uintptr_t;

--- a/usertests.c
+++ b/usertests.c
@@ -1451,7 +1451,7 @@ sbrktest(void)
   // can one grow address space to something big?
 #define BIG (100*1024*1024)
   a = sbrk(0);
-  amt = (BIG) - (uint)a;
+  amt = (BIG) - (uintptr_t)a;
   p = sbrk(amt);
   if (p != a) {
     printf(stdout, "sbrk test failed to grow big address space; enough phys mem?\n");
@@ -1518,7 +1518,7 @@ sbrktest(void)
   for(i = 0; i < sizeof(pids)/sizeof(pids[0]); i++){
     if((pids[i] = fork()) == 0){
       // allocate a lot of memory
-      sbrk(BIG - (uint)sbrk(0));
+      sbrk(BIG - (uintptr_t)sbrk(0));
       write(fds[1], "x", 1);
       // sit around until killed
       for(;;) sleep(1000);
@@ -1568,10 +1568,10 @@ validatetest(void)
   printf(stdout, "validate test\n");
   hi = 1100*1024;
 
-  for(p = 0; p <= (uint)hi; p += 4096){
+  for(p = 0; p <= (uintptr_t)hi; p += 4096){
     if((pid = fork()) == 0){
       // try to crash the kernel by passing in a badly placed integer
-      validateint((int*)p);
+      validateint((int*)(uintptr_t)p);
       exit();
     }
     sleep(0);
@@ -1580,7 +1580,7 @@ validatetest(void)
     wait();
 
     // try to crash the kernel by passing in a bad string pointer
-    if(link("nosuchfile", (char*)p) != -1){
+    if(link("nosuchfile", (char*)(uintptr_t)p) != -1){
       printf(stdout, "link should not succeed\n");
       exit();
     }

--- a/x86.h
+++ b/x86.h
@@ -65,8 +65,8 @@ lgdt(struct segdesc *p, int size)
   volatile ushort pd[3];
 
   pd[0] = size-1;
-  pd[1] = (uint)p;
-  pd[2] = (uint)p >> 16;
+  pd[1] = (uintptr_t)p;
+  pd[2] = (uintptr_t)p >> 16;
 
   asm volatile("lgdt (%0)" : : "r" (pd));
 }
@@ -79,8 +79,8 @@ lidt(struct gatedesc *p, int size)
   volatile ushort pd[3];
 
   pd[0] = size-1;
-  pd[1] = (uint)p;
-  pd[2] = (uint)p >> 16;
+  pd[1] = (uintptr_t)p;
+  pd[2] = (uintptr_t)p >> 16;
 
   asm volatile("lidt (%0)" : : "r" (pd));
 }


### PR DESCRIPTION
## Summary
- add build matrix for i686 and x86_64
- create 64-bit image names in Makefile
- document ARCH=x86_64 artifacts in README
- tweak various source files for 64-bit cross-builds

## Testing
- `make clean >/dev/null && make ARCH=i686 QEMU=echo qemu-nox`