### PR TITLE
Add basic x86_64 paging support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ OBJS = \
 	trap.o\
 	uart.o\
 	vectors.o\
-	vm.o\
+        vm.o\
+
+ifeq ($(ARCH),x86_64)
+OBJS += mmu64.o
+endif
 
 # Cross-compiling (e.g., on Mac OS X)
 # TOOLPREFIX = i386-jos-elf

--- a/defs.h
+++ b/defs.h
@@ -174,6 +174,9 @@ void            uartputc(int);
 void            seginit(void);
 void            kvmalloc(void);
 pde_t*          setupkvm(void);
+#ifdef __x86_64__
+pml4e_t*        setupkvm64(void);
+#endif
 char*           uva2ka(pde_t*, char*);
 int             allocuvm(pde_t*, uint, uint);
 int             deallocuvm(pde_t*, uint, uint);

--- a/main.c
+++ b/main.c
@@ -8,7 +8,11 @@
 
 static void startothers(void);
 static void mpmain(void)  __attribute__((noreturn));
+#ifdef __x86_64__
+extern pml4e_t *kpgdir;
+#else
 extern pde_t *kpgdir;
+#endif
 extern char end[]; // first address after kernel loaded from ELF file
 
 // Bootstrap processor starts running C code here.
@@ -57,7 +61,11 @@ mpmain(void)
   scheduler();     // start running processes
 }
 
+#ifdef __x86_64__
+pml4e_t entrypgdir[];  // For entry.S
+#else
 pde_t entrypgdir[];  // For entry.S
+#endif
 
 // Start the non-boot (AP) processors.
 static void
@@ -100,7 +108,11 @@ startothers(void)
 // PTE_PS in a page directory entry enables 4Mbyte pages.
 
 __attribute__((__aligned__(PGSIZE)))
+#ifdef __x86_64__
+pml4e_t entrypgdir[NPDENTRIES] = {
+#else
 pde_t entrypgdir[NPDENTRIES] = {
+#endif
   // Map VA's [0, 4MB) to PA's [0, 4MB)
   [0] = (0) | PTE_P | PTE_W | PTE_PS,
   // Map VA's [KERNBASE, KERNBASE+4MB) to PA's [0, 4MB)

--- a/mmu64.c
+++ b/mmu64.c
@@ -1,0 +1,101 @@
+#ifdef __x86_64__
+#include "param.h"
+#include "types.h"
+#include "defs.h"
+#include "memlayout.h"
+#include "mmu.h"
+#include "proc.h"
+
+extern char data[];
+
+static pte_t *
+walkpml4(pml4e_t *pml4, const void *va, int alloc)
+{
+  pml4e_t *pml4e;
+  pdpe_t *pdp;
+  pdpe_t *pdpe;
+  pde_t *pd;
+  pte_t *pt;
+
+  pml4e = &pml4[PML4(va)];
+  if(*pml4e & PTE_P){
+    pdp = (pdpe_t*)P2V(PTE_ADDR(*pml4e));
+  } else {
+    if(!alloc || (pdp = (pdpe_t*)kalloc()) == 0)
+      return 0;
+    memset(pdp, 0, PGSIZE);
+    *pml4e = V2P(pdp) | PTE_P | PTE_W | PTE_U;
+  }
+
+  pdpe = &pdp[PDPX(va)];
+  if(*pdpe & PTE_P){
+    pd = (pde_t*)P2V(PTE_ADDR(*pdpe));
+  } else {
+    if(!alloc || (pd = (pde_t*)kalloc()) == 0)
+      return 0;
+    memset(pd, 0, PGSIZE);
+    *pdpe = V2P(pd) | PTE_P | PTE_W | PTE_U;
+  }
+
+  pde_t *pde = &pd[PDX(va)];
+  if(*pde & PTE_P){
+    pt = (pte_t*)P2V(PTE_ADDR(*pde));
+  } else {
+    if(!alloc || (pt = (pte_t*)kalloc()) == 0)
+      return 0;
+    memset(pt, 0, PGSIZE);
+    *pde = V2P(pt) | PTE_P | PTE_W | PTE_U;
+  }
+
+  return &pt[PTX(va)];
+}
+
+static int
+mappages64(pml4e_t *pml4, void *va, uint size, uint64 pa, int perm)
+{
+  char *a, *last;
+  pte_t *pte;
+
+  a = (char*)PGROUNDDOWN((uint64)va);
+  last = (char*)PGROUNDDOWN(((uint64)va) + size - 1);
+  for(;;){
+    if((pte = walkpml4(pml4, a, 1)) == 0)
+      return -1;
+    if(*pte & PTE_P)
+      panic("remap");
+    *pte = pa | perm | PTE_P;
+    if(a == last)
+      break;
+    a += PGSIZE;
+    pa += PGSIZE;
+  }
+  return 0;
+}
+
+pml4e_t*
+setupkvm64(void)
+{
+  pml4e_t *pml4;
+  struct kmap { void *virt; uint phys_start; uint phys_end; int perm; };
+  static struct kmap kmap[] = {
+    { (void*)KERNBASE, 0,             EXTMEM,    PTE_W},
+    { (void*)KERNLINK, V2P(KERNLINK), V2P(data), 0},
+    { (void*)data,     V2P(data),     PHYSTOP,   PTE_W},
+    { (void*)DEVSPACE, DEVSPACE,      0,         PTE_W},
+  };
+  struct kmap *k;
+
+  if((pml4 = (pml4e_t*)kalloc()) == 0)
+    return 0;
+  memset(pml4, 0, PGSIZE);
+  if (P2V(PHYSTOP) > (void*)DEVSPACE)
+    panic("PHYSTOP too high");
+  for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
+    if(mappages64(pml4, k->virt, k->phys_end - k->phys_start,
+                  (uint64)k->phys_start, k->perm) < 0) {
+      kfree((char*)pml4);
+      return 0;
+    }
+  return pml4;
+}
+#endif

--- a/types.h
+++ b/types.h
@@ -1,4 +1,10 @@
 typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;
+typedef unsigned long long uint64;
+
+#ifdef __x86_64__
+typedef uint64 pde_t;
+#else
 typedef uint pde_t;
+#endif

--- a/vm.c
+++ b/vm.c
@@ -8,7 +8,11 @@
 #include "elf.h"
 
 extern char data[];  // defined by kernel.ld
+#ifdef __x86_64__
+pml4e_t *kpgdir;  // for use in scheduler()
+#else
 pde_t *kpgdir;  // for use in scheduler()
+#endif
 
 // Set up CPU's kernel segment descriptors.
 // Run once on entry on each CPU.
@@ -140,7 +144,11 @@ setupkvm(void)
 void
 kvmalloc(void)
 {
+#ifdef __x86_64__
+  kpgdir = setupkvm64();
+#else
   kpgdir = setupkvm();
+#endif
   switchkvm();
 }
 

--- a/x86.h
+++ b/x86.h
@@ -65,8 +65,13 @@ lgdt(struct segdesc *p, int size)
   volatile ushort pd[3];
 
   pd[0] = size-1;
+#ifdef __x86_64__
+  pd[1] = (uint64)p;
+  pd[2] = (uint64)p >> 16;
+#else
   pd[1] = (uint)p;
   pd[2] = (uint)p >> 16;
+#endif
 
   asm volatile("lgdt (%0)" : : "r" (pd));
 }
@@ -79,8 +84,13 @@ lidt(struct gatedesc *p, int size)
   volatile ushort pd[3];
 
   pd[0] = size-1;
+#ifdef __x86_64__
+  pd[1] = (uint64)p;
+  pd[2] = (uint64)p >> 16;
+#else
   pd[1] = (uint)p;
   pd[2] = (uint)p >> 16;
+#endif
 
   asm volatile("lidt (%0)" : : "r" (pd));
 }
@@ -130,6 +140,21 @@ xchg(volatile uint *addr, uint newval)
   return result;
 }
 
+#ifdef __x86_64__
+static inline uint64
+rcr2(void)
+{
+  uint64 val;
+  asm volatile("movq %%cr2,%0" : "=r" (val));
+  return val;
+}
+
+static inline void
+lcr3(uint64 val)
+{
+  asm volatile("movq %0,%%cr3" : : "r" (val));
+}
+#else
 static inline uint
 rcr2(void)
 {
@@ -143,6 +168,7 @@ lcr3(uint val)
 {
   asm volatile("movl %0,%%cr3" : : "r" (val));
 }
+#endif
 
 //PAGEBREAK: 36
 // Layout of the trap frame built on the stack by the


### PR DESCRIPTION
## Summary
- add 64-bit pgtables and address macros
- provide helper routines for building 4‑level tables
- call the new helpers when building kernel mappings
- extend x86 helpers for 64-bit CR3

## Testing
- `make qemu-nox QEMU=echo`
