### PR TITLE
Enable 64bit page table types

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -183,7 +183,11 @@ int             loaduvm(pde_t*, char*, struct inode*, uint, uint);
 pde_t*          copyuvm(pde_t*, uint);
 void            switchuvm(struct proc*);
 void            switchkvm(void);
+#ifdef __x86_64__
+int             copyout(pde_t*, uint64, void*, uint);
+#else
 int             copyout(pde_t*, uint, void*, uint);
+#endif
 void            clearpteu(pde_t *pgdir, char *uva);
 
 // number of elements in fixed-size array

--- a/kalloc.c
+++ b/kalloc.c
@@ -47,7 +47,7 @@ void
 freerange(void *vstart, void *vend)
 {
   char *p;
-  p = (char*)PGROUNDUP((uint)vstart);
+  p = (char*)PGROUNDUP((uintptr_t)vstart);
   for(; p + PGSIZE <= (char*)vend; p += PGSIZE)
     kfree(p);
 }
@@ -61,7 +61,7 @@ kfree(char *v)
 {
   struct run *r;
 
-  if((uint)v % PGSIZE || v < end || V2P(v) >= PHYSTOP)
+  if((uintptr_t)v % PGSIZE || v < end || V2P(v) >= PHYSTOP)
     panic("kfree");
 
   // Fill with junk to catch dangling refs.

--- a/main.c
+++ b/main.c
@@ -72,7 +72,11 @@ startothers(void)
   // The linker has placed the image of entryother.S in
   // _binary_entryother_start.
   code = P2V(0x7000);
+#ifdef __x86_64__
+  memmove(code, _binary_entryother_start, (uint64)_binary_entryother_size);
+#else
   memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
+#endif
 
   for(c = cpus; c < cpus+ncpu; c++){
     if(c == mycpu())  // We've started already.

--- a/memlayout.h
+++ b/memlayout.h
@@ -8,8 +8,13 @@
 #define KERNBASE 0x80000000         // First kernel virtual address
 #define KERNLINK (KERNBASE+EXTMEM)  // Address where kernel is linked
 
+#ifdef __x86_64__
+#define V2P(a) (((uint64)(a)) - KERNBASE)
+#define P2V(a) ((void *)(((char *)(a)) + KERNBASE))
+#else
 #define V2P(a) (((uint) (a)) - KERNBASE)
 #define P2V(a) ((void *)(((char *) (a)) + KERNBASE))
+#endif
 
 #define V2P_WO(x) ((x) - KERNBASE)    // same as V2P, but without casts
 #define P2V_WO(x) ((x) + KERNBASE)    // same as P2V, but without casts

--- a/mmu.h
+++ b/mmu.h
@@ -71,13 +71,25 @@ struct segdesc {
 //  \--- PDX(va) --/ \--- PTX(va) --/
 
 // page directory index
+#ifdef __x86_64__
+#define PDX(va)         (((uint64)(va) >> PDXSHIFT) & 0x3FF)
+#else
 #define PDX(va)         (((uint)(va) >> PDXSHIFT) & 0x3FF)
+#endif
 
 // page table index
+#ifdef __x86_64__
+#define PTX(va)         (((uint64)(va) >> PTXSHIFT) & 0x3FF)
+#else
 #define PTX(va)         (((uint)(va) >> PTXSHIFT) & 0x3FF)
+#endif
 
 // construct virtual address from indexes and offset
+#ifdef __x86_64__
+#define PGADDR(d, t, o) ((uint64)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#else
 #define PGADDR(d, t, o) ((uint)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#endif
 
 // Page directory and page table constants.
 #define NPDENTRIES      1024    // # directory entries per page directory
@@ -97,11 +109,20 @@ struct segdesc {
 #define PTE_PS          0x080   // Page Size
 
 // Address in page table or page directory entry
+#ifdef __x86_64__
+#define PTE_ADDR(pte)   ((uint64)(pte) & ~0xFFFULL)
+#define PTE_FLAGS(pte)  ((uint64)(pte) &  0xFFF)
+#else
 #define PTE_ADDR(pte)   ((uint)(pte) & ~0xFFF)
 #define PTE_FLAGS(pte)  ((uint)(pte) &  0xFFF)
+#endif
 
 #ifndef __ASSEMBLER__
+#ifdef __x86_64__
+typedef uint64 pte_t;
+#else
 typedef uint pte_t;
+#endif
 
 // Task state segment format
 struct taskstate {

--- a/sh.c
+++ b/sh.c
@@ -58,10 +58,7 @@ static void runcmd(struct cmd *cmd) __attribute__((noreturn));
 
 // Execute cmd.  Never returns.
 
-static void
-
 static void __attribute__((noreturn))
-
 runcmd(struct cmd *cmd)
 {
   int p[2];

--- a/types.h
+++ b/types.h
@@ -1,5 +1,11 @@
 typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;
+typedef unsigned long long uint64;
+
+#ifdef __x86_64__
+typedef uint64 pde_t;
+#else
 typedef uint pde_t;
+#endif
 typedef unsigned long uintptr_t;

--- a/vm.c
+++ b/vm.c
@@ -63,8 +63,8 @@ mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm)
   char *a, *last;
   pte_t *pte;
 
-  a = (char*)PGROUNDDOWN((uint)va);
-  last = (char*)PGROUNDDOWN(((uint)va) + size - 1);
+  a = (char*)PGROUNDDOWN((uintptr_t)va);
+  last = (char*)PGROUNDDOWN(((uintptr_t)va) + size - 1);
   for(;;){
     if((pte = walkpgdir(pgdir, a, 1)) == 0)
       return -1;
@@ -128,7 +128,7 @@ setupkvm(void)
     panic("PHYSTOP too high");
   for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
     if(mappages(pgdir, k->virt, k->phys_end - k->phys_start,
-                (uint)k->phys_start, k->perm) < 0) {
+                (uintptr_t)k->phys_start, k->perm) < 0) {
       freevm(pgdir);
       return 0;
     }
@@ -168,7 +168,7 @@ switchuvm(struct proc *p)
                                 sizeof(mycpu()->ts)-1, 0);
   mycpu()->gdt[SEG_TSS].s = 0;
   mycpu()->ts.ss0 = SEG_KDATA << 3;
-  mycpu()->ts.esp0 = (uint)p->kstack + KSTACKSIZE;
+  mycpu()->ts.esp0 = (uintptr_t)p->kstack + KSTACKSIZE;
   // setting IOPL=0 in eflags *and* iomb beyond the tss segment limit
   // forbids I/O instructions (e.g., inb and outb) from user space
   mycpu()->ts.iomb = (ushort) 0xFFFF;
@@ -200,7 +200,7 @@ loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz)
   uint i, pa, n;
   pte_t *pte;
 
-  if((uint) addr % PGSIZE != 0)
+  if((uintptr_t) addr % PGSIZE != 0)
     panic("loaduvm: addr must be page aligned");
   for(i = 0; i < sz; i += PGSIZE){
     if((pte = walkpgdir(pgdir, addr+i, 0)) == 0)
@@ -363,14 +363,27 @@ uva2ka(pde_t *pgdir, char *uva)
 // Most useful when pgdir is not the current page table.
 // uva2ka ensures this only works for PTE_U pages.
 int
+#ifdef __x86_64__
+copyout(pde_t *pgdir, uint64 va, void *p, uint len)
+#else
 copyout(pde_t *pgdir, uint va, void *p, uint len)
+#endif
 {
   char *buf, *pa0;
-  uint n, va0;
+  uint n;
+#ifdef __x86_64__
+  uint64 va0;
+#else
+  uint va0;
+#endif
 
   buf = (char*)p;
   while(len > 0){
+#ifdef __x86_64__
+    va0 = (uint64)PGROUNDDOWN(va);
+#else
     va0 = (uint)PGROUNDDOWN(va);
+#endif
     pa0 = uva2ka(pgdir, (char*)va0);
     if(pa0 == 0)
       return -1;

--- a/x86.h
+++ b/x86.h
@@ -130,6 +130,21 @@ xchg(volatile uint *addr, uint newval)
   return result;
 }
 
+#ifdef __x86_64__
+static inline uint64
+rcr2(void)
+{
+  uint64 val;
+  asm volatile("movq %%cr2,%0" : "=r" (val));
+  return val;
+}
+
+static inline void
+lcr3(uint64 val)
+{
+  asm volatile("movq %0,%%cr3" : : "r" (val));
+}
+#else
 static inline uint
 rcr2(void)
 {
@@ -143,6 +158,7 @@ lcr3(uint val)
 {
   asm volatile("movl %0,%%cr3" : : "r" (val));
 }
+#endif
 
 //PAGEBREAK: 36
 // Layout of the trap frame built on the stack by the


### PR DESCRIPTION
## Summary
- add `uint64` in `types.h`
- support 64-bit `pde_t`/`pte_t`
- update address macros and casts for x86_64
- adjust rcr2/lcr3 for 64-bit
- fix a spurious declaration in `sh.c`

## Testing
- `make ARCH=i686 QEMU=echo qemu-nox`