### PR TITLE
Add x86_64 context switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ OBJS = \
 	sleeplock.o\
 	spinlock.o\
 	string.o\
-	swtch.o\
 	syscall.o\
 	sysfile.o\
 	sysproc.o\
@@ -75,10 +74,11 @@ ARCH ?= i686
 CSTD ?= gnu2x
 
 ifeq ($(ARCH),x86_64)
-OBJS += main64.o
+OBJS += main64.o swtch64.o
 BOOTASM := arch/x64/bootasm64.S
 ENTRYASM := arch/x64/entry64.S
 else
+OBJS += swtch.o
 BOOTASM := bootasm.S
 ENTRYASM := entry.S
 endif

--- a/defs.h
+++ b/defs.h
@@ -1,5 +1,11 @@
 struct buf;
 struct context;
+#ifdef __x86_64__
+struct context64;
+typedef struct context64 context_t;
+#else
+typedef struct context context_t;
+#endif
 struct file;
 struct inode;
 struct pipe;
@@ -122,7 +128,7 @@ void            wakeup(void*);
 void            yield(void);
 
 // swtch.S
-void            swtch(struct context**, struct context*);
+void            swtch(context_t**, context_t*);
 
 // spinlock.c
 void            acquire(struct spinlock*);

--- a/proc.c
+++ b/proc.c
@@ -104,13 +104,22 @@ found:
 
   // Set up new context to start executing at forkret,
   // which returns to trapret.
+#ifdef __x86_64__
+  sp -= sizeof(unsigned long);
+  *(unsigned long*)sp = (unsigned long)trapret;
+#else
   sp -= 4;
   *(uint*)sp = (uint)trapret;
+#endif
 
   sp -= sizeof *p->context;
-  p->context = (struct context*)sp;
+  p->context = (context_t*)sp;
   memset(p->context, 0, sizeof *p->context);
+#ifdef __x86_64__
+  p->context->rip = (unsigned long)forkret;
+#else
   p->context->eip = (uint)forkret;
+#endif
 
   return p;
 }
@@ -525,7 +534,11 @@ procdump(void)
       state = "???";
     cprintf("%d %s %s", p->pid, state, p->name);
     if(p->state == SLEEPING){
+#ifdef __x86_64__
+      getcallerpcs((void*)p->context->rbp + 2*sizeof(uintptr_t), pc);
+#else
       getcallerpcs((uint*)p->context->ebp+2, pc);
+#endif
       for(i=0; i<10 && pc[i] != 0; i++)
         cprintf(" %p", pc[i]);
     }

--- a/proc.h
+++ b/proc.h
@@ -1,7 +1,16 @@
+// Context used for kernel context switches.
+#ifdef __x86_64__
+struct context64;
+typedef struct context64 context_t;
+#else
+struct context;
+typedef struct context context_t;
+#endif
+
 // Per-CPU state
 struct cpu {
   uchar apicid;                // Local APIC ID
-  struct context *scheduler;   // swtch() here to enter scheduler
+  context_t *scheduler;        // swtch() here to enter scheduler
   struct taskstate ts;         // Used by x86 to find stack for interrupt
   struct segdesc gdt[NSEGS];   // x86 global descriptor table
   volatile uint started;       // Has the CPU started?
@@ -32,6 +41,19 @@ struct context {
   uint eip;
 };
 
+#ifdef __x86_64__
+struct context64 {
+  unsigned long r15;
+  unsigned long r14;
+  unsigned long r13;
+  unsigned long r12;
+  unsigned long rbx;
+  unsigned long rbp;
+  unsigned long rip;
+};
+#endif
+
+
 enum procstate { UNUSED, EMBRYO, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 
 // Per-process state
@@ -43,7 +65,7 @@ struct proc {
   int pid;                     // Process ID
   struct proc *parent;         // Parent process
   struct trapframe *tf;        // Trap frame for current syscall
-  struct context *context;     // swtch() here to run process
+  context_t *context;          // swtch() here to run process
   void *chan;                  // If non-zero, sleeping on chan
   int killed;                  // If non-zero, have been killed
   struct file *ofile[NOFILE];  // Open files

--- a/sh.c
+++ b/sh.c
@@ -57,11 +57,7 @@ struct cmd *parsecmd(char*);
 static void runcmd(struct cmd *cmd) __attribute__((noreturn));
 
 // Execute cmd.  Never returns.
-
-static void
-
 static void __attribute__((noreturn))
-
 runcmd(struct cmd *cmd)
 {
   int p[2];

--- a/spinlock.c
+++ b/spinlock.c
@@ -71,6 +71,21 @@ release(struct spinlock *lk)
 void
 getcallerpcs(void *v, uint pcs[])
 {
+#ifdef __x86_64__
+  unsigned long *rbp;
+  int i;
+
+  rbp = (unsigned long*)v - 2;
+  for(i = 0; i < 10; i++){
+    if(rbp == 0 || rbp < (unsigned long*)KERNBASE ||
+       rbp == (unsigned long*)-1)
+      break;
+    pcs[i] = rbp[1];     // saved %rip
+    rbp = (unsigned long*)rbp[0]; // saved %rbp
+  }
+  for(; i < 10; i++)
+    pcs[i] = 0;
+#else
   uint *ebp;
   int i;
 
@@ -83,6 +98,7 @@ getcallerpcs(void *v, uint pcs[])
   }
   for(; i < 10; i++)
     pcs[i] = 0;
+#endif
 }
 
 // Check whether this cpu is holding the lock.

--- a/swtch64.S
+++ b/swtch64.S
@@ -1,0 +1,33 @@
+# Context switch for x86_64
+#
+#   void swtch(struct context64 **old, struct context64 *new);
+#
+# Save the current registers on the stack, creating a struct context64
+# and save its address in *old. Switch stacks to new and restore
+# previously saved registers.
+
+.globl swtch
+swtch:
+    movq %rdi, %rax      # old
+    movq %rsi, %rdx      # new
+
+    # Save old callee-saved registers
+    pushq %rbp
+    pushq %rbx
+    pushq %r12
+    pushq %r13
+    pushq %r14
+    pushq %r15
+
+    # Switch stacks
+    movq %rsp, (%rax)
+    movq %rdx, %rsp
+
+    # Load new callee-saved registers
+    popq %r15
+    popq %r14
+    popq %r13
+    popq %r12
+    popq %rbx
+    popq %rbp
+    ret


### PR DESCRIPTION
## Summary
- implement `swtch64.S` for 64-bit context switching
- support `struct context64` when compiling for x86_64
- adjust scheduler and process creation to use the proper context

## Testing
- `make qemu-nox QEMU=echo`
- `make ARCH=x86_64 QEMU=echo` *(fails: `bootasm64.S` assembler errors)*