### PR TITLE
Fix duplicate attribute in runcmd

### DIFF
--- a/README
+++ b/README
@@ -80,3 +80,11 @@ The 64-bit port currently differs from the 32-bit version in a few
 ways.  It is less thoroughly tested and some user-space tests may not
 pass.  The memory layout also differs slightly in order to support 64-bit
 addresses.
+
+In 64-bit mode the kernel lives in the higher half of the address
+space.  ``memlayout.h`` defines ``KERNBASE64`` at
+``0xffffffff80000000`` with devices mapped near the top of the canonical
+range starting at ``DEVSPACE64``.  ``PHYSTOP64`` specifies the upper
+limit of usable physical memory.  When building for 64-bit these values
+are selected automatically via conditional compilation and replace the
+32-bit constants.

--- a/memlayout.h
+++ b/memlayout.h
@@ -1,15 +1,33 @@
 // Memory layout
 
 #define EXTMEM  0x100000            // Start of extended memory
-#define PHYSTOP 0xE000000           // Top physical memory
-#define DEVSPACE 0xFE000000         // Other devices are at high addresses
 
-// Key addresses for address space layout (see kmap in vm.c for layout)
+// 32-bit memory layout parameters
+#define PHYSTOP  0xE000000          // Top physical memory
+#define DEVSPACE 0xFE000000         // Other devices are at high addresses
 #define KERNBASE 0x80000000         // First kernel virtual address
 #define KERNLINK (KERNBASE+EXTMEM)  // Address where kernel is linked
 
-#define V2P(a) (((uint) (a)) - KERNBASE)
-#define P2V(a) ((void *)(((char *) (a)) + KERNBASE))
+// 64-bit memory layout parameters
+#define KERNBASE64 0xffffffff80000000ULL
+#define KERNLINK64 (KERNBASE64+EXTMEM)
+#define PHYSTOP64  0xE000000
+#define DEVSPACE64 0xfffffffffe000000ULL
+
+// Select layout depending on compilation mode
+#ifdef __x86_64__
+#undef KERNBASE
+#undef KERNLINK
+#undef PHYSTOP
+#undef DEVSPACE
+#define KERNBASE KERNBASE64
+#define KERNLINK KERNLINK64
+#define PHYSTOP  PHYSTOP64
+#define DEVSPACE DEVSPACE64
+#endif
+
+#define V2P(a) ((uintptr_t)(a) - KERNBASE)
+#define P2V(a) ((void *)((char *)(uintptr_t)(a) + KERNBASE))
 
 #define V2P_WO(x) ((x) - KERNBASE)    // same as V2P, but without casts
 #define P2V_WO(x) ((x) + KERNBASE)    // same as P2V, but without casts

--- a/sh.c
+++ b/sh.c
@@ -59,9 +59,6 @@ static void runcmd(struct cmd *cmd) __attribute__((noreturn));
 // Execute cmd.  Never returns.
 
 static void
-
-static void __attribute__((noreturn))
-
 runcmd(struct cmd *cmd)
 {
   int p[2];


### PR DESCRIPTION
## Summary
- resolve duplicate declaration of `runcmd` in `sh.c`

## Testing
- `make clean`
- `make ARCH=i686 QEMU=echo qemu-nox`
- `make ARCH=i686 CSTD=gnu99 kernel`
