### PR TITLE
Cleanup headers for C23 build

### DIFF
--- a/memlayout.h
+++ b/memlayout.h
@@ -1,18 +1,17 @@
 // Memory layout
 
-#define EXTMEM  0x100000            // Start of extended memory
+#define EXTMEM 0x100000 // Start of extended memory
 
 // 32-bit memory layout parameters
-#define PHYSTOP  0xE000000          // Top physical memory
-#define DEVSPACE 0xFE000000         // Other devices are at high addresses
-#define KERNBASE 0x80000000         // First kernel virtual address
-#define KERNLINK (KERNBASE+EXTMEM)  // Address where kernel is linked
-
+#define PHYSTOP 0xE000000            // Top physical memory
+#define DEVSPACE 0xFE000000          // Other devices are at high addresses
+#define KERNBASE 0x80000000          // First kernel virtual address
+#define KERNLINK (KERNBASE + EXTMEM) // Address where kernel is linked
 
 // 64-bit memory layout parameters
 #define KERNBASE64 0xffffffff80000000ULL
-#define KERNLINK64 (KERNBASE64+EXTMEM)
-#define PHYSTOP64  0xE000000
+#define KERNLINK64 (KERNBASE64 + EXTMEM)
+#define PHYSTOP64 0xE000000
 #define DEVSPACE64 0xfffffffffe000000ULL
 
 // Select layout depending on compilation mode
@@ -23,21 +22,17 @@
 #undef DEVSPACE
 #define KERNBASE KERNBASE64
 #define KERNLINK KERNLINK64
-#define PHYSTOP  PHYSTOP64
+#define PHYSTOP PHYSTOP64
 #define DEVSPACE DEVSPACE64
 #endif
-
-#define V2P(a) ((uintptr_t)(a) - KERNBASE)
-#define P2V(a) ((void *)((char *)(uintptr_t)(a) + KERNBASE))
 
 #ifdef __x86_64__
 #define V2P(a) (((uint64)(a)) - KERNBASE)
 #define P2V(a) ((void *)(((char *)(a)) + KERNBASE))
 #else
-#define V2P(a) (((uint) (a)) - KERNBASE)
-#define P2V(a) ((void *)(((char *) (a)) + KERNBASE))
+#define V2P(a) (((uint)(a)) - KERNBASE)
+#define P2V(a) ((void *)(((char *)(a)) + KERNBASE))
 #endif
 
-
-#define V2P_WO(x) ((x) - KERNBASE)    // same as V2P, but without casts
-#define P2V_WO(x) ((x) + KERNBASE)    // same as P2V, but without casts
+#define V2P_WO(x) ((x) - KERNBASE) // same as V2P, but without casts
+#define P2V_WO(x) ((x) + KERNBASE) // same as P2V, but without casts

--- a/mmu.h
+++ b/mmu.h
@@ -2,24 +2,24 @@
 // x86 memory management unit (MMU).
 
 // Eflags register
-#define FL_IF           0x00000200      // Interrupt Enable
+#define FL_IF 0x00000200 // Interrupt Enable
 
 // Control Register flags
-#define CR0_PE          0x00000001      // Protection Enable
-#define CR0_WP          0x00010000      // Write Protect
-#define CR0_PG          0x80000000      // Paging
+#define CR0_PE 0x00000001 // Protection Enable
+#define CR0_WP 0x00010000 // Write Protect
+#define CR0_PG 0x80000000 // Paging
 
-#define CR4_PSE         0x00000010      // Page size extension
+#define CR4_PSE 0x00000010 // Page size extension
 
 // various segment selectors.
-#define SEG_KCODE 1  // kernel code
-#define SEG_KDATA 2  // kernel data+stack
-#define SEG_UCODE 3  // user code
-#define SEG_UDATA 4  // user data+stack
-#define SEG_TSS   5  // this process's task state
+#define SEG_KCODE 1 // kernel code
+#define SEG_KDATA 2 // kernel data+stack
+#define SEG_UCODE 3 // user code
+#define SEG_UDATA 4 // user data+stack
+#define SEG_TSS 5   // this process's task state
 
 // cpu->gdt[NSEGS] holds the above segments.
-#define NSEGS     6
+#define NSEGS 6
 
 #ifndef __ASSEMBLER__
 // Segment Descriptor
@@ -40,27 +40,47 @@ struct segdesc {
 };
 
 // Normal segment
-#define SEG(type, base, lim, dpl) (struct segdesc)    \
-{ ((lim) >> 12) & 0xffff, (uint)(base) & 0xffff,      \
-  ((uint)(base) >> 16) & 0xff, type, 1, dpl, 1,       \
-  (uint)(lim) >> 28, 0, 0, 1, 1, (uint)(base) >> 24 }
-#define SEG16(type, base, lim, dpl) (struct segdesc)  \
-{ (lim) & 0xffff, (uint)(base) & 0xffff,              \
-  ((uint)(base) >> 16) & 0xff, type, 1, dpl, 1,       \
-  (uint)(lim) >> 16, 0, 0, 1, 0, (uint)(base) >> 24 }
+#define SEG(type, base, lim, dpl)                                              \
+  (struct segdesc){((lim) >> 12) & 0xffff,                                     \
+                   (uint)(base) & 0xffff,                                      \
+                   ((uint)(base) >> 16) & 0xff,                                \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint)(lim) >> 28,                                          \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   1,                                                          \
+                   (uint)(base) >> 24}
+#define SEG16(type, base, lim, dpl)                                            \
+  (struct segdesc){(lim) & 0xffff,                                             \
+                   (uint)(base) & 0xffff,                                      \
+                   ((uint)(base) >> 16) & 0xff,                                \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint)(lim) >> 16,                                          \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   0,                                                          \
+                   (uint)(base) >> 24}
 #endif
 
-#define DPL_USER    0x3     // User DPL
+#define DPL_USER 0x3 // User DPL
 
 // Application segment type bits
-#define STA_X       0x8     // Executable segment
-#define STA_W       0x2     // Writeable (non-executable segments)
-#define STA_R       0x2     // Readable (executable segments)
+#define STA_X 0x8 // Executable segment
+#define STA_W 0x2 // Writeable (non-executable segments)
+#define STA_R 0x2 // Readable (executable segments)
 
 // System segment type bits
-#define STS_T32A    0x9     // Available 32-bit TSS
-#define STS_IG32    0xE     // 32-bit Interrupt Gate
-#define STS_TG32    0xF     // 32-bit Trap Gate
+#define STS_T32A 0x9 // Available 32-bit TSS
+#define STS_IG32 0xE // 32-bit Interrupt Gate
+#define STS_TG32 0xF // 32-bit Trap Gate
 
 // A virtual address 'la' has a three-part structure as follows:
 //
@@ -72,99 +92,76 @@ struct segdesc {
 
 // page directory index
 #ifdef __x86_64__
-
-#define PDX(va)         (((uint64)(va) >> PDXSHIFT) & 0x3FF)
+#define PML4(va) (((uint64)(va) >> PML4SHIFT) & 0x1FF)
+#define PDPX(va) (((uint64)(va) >> PDPSHIFT) & 0x1FF)
+#define PDX(va) (((uint64)(va) >> PDSHIFT) & 0x1FF)
+#define PTX(va) (((uint64)(va) >> PTSHIFT) & 0x1FF)
 #else
-#define PDX(va)         (((uint)(va) >> PDXSHIFT) & 0x3FF)
-#endif
-
-// page table index
-#ifdef __x86_64__
-#define PTX(va)         (((uint64)(va) >> PTXSHIFT) & 0x3FF)
-#else
-
-#define PML4(va)        (((uint64)(va) >> PML4SHIFT) & 0x1FF)
-#define PDPX(va)        (((uint64)(va) >> PDPSHIFT) & 0x1FF)
-#define PDX(va)         (((uint64)(va) >> PDSHIFT) & 0x1FF)
-#define PTX(va)         (((uint64)(va) >> PTSHIFT) & 0x1FF)
-#else
-#define PDX(va)         (((uint)(va) >> PDXSHIFT) & 0x3FF)
-
-#define PTX(va)         (((uint)(va) >> PTXSHIFT) & 0x3FF)
+#define PDX(va) (((uint)(va) >> PDXSHIFT) & 0x3FF)
+#define PTX(va) (((uint)(va) >> PTXSHIFT) & 0x3FF)
 #endif
 
 // construct virtual address from indexes and offset
 #ifdef __x86_64__
-
-#define PGADDR(d, t, o) ((uint64)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
-=======
-
-  ((uint64)((l4) << PML4SHIFT | (l3) << PDPSHIFT | \
-            (l2) << PDSHIFT | (l1) << PTSHIFT | (o)))
-
+#define PGADDR(l4, l3, l2, l1, o)                                              \
+  ((uint64)((l4) << PML4SHIFT | (l3) << PDPSHIFT | (l2) << PDSHIFT |           \
+            (l1) << PTSHIFT | (o)))
 #else
 #define PGADDR(d, t, o) ((uint)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
 #endif
 
 // Page directory and page table constants.
 #ifdef __x86_64__
-#define NPDENTRIES      512     // entries per page directory
-#define NPTENTRIES      512     // PTEs per page table
+#define NPDENTRIES 512 // entries per page directory
+#define NPTENTRIES 512 // PTEs per page table
 #else
-#define NPDENTRIES      1024    // # directory entries per page directory
-#define NPTENTRIES      1024    // # PTEs per page table
+#define NPDENTRIES 1024 // # directory entries per page directory
+#define NPTENTRIES 1024 // # PTEs per page table
 #endif
-#define PGSIZE          4096    // bytes mapped by a page
+#define PGSIZE 4096 // bytes mapped by a page
 
 #ifdef __x86_64__
-#define PTSHIFT         12
-#define PDSHIFT         21
-#define PDPSHIFT        30
-#define PML4SHIFT       39
+#define PTSHIFT 12
+#define PDSHIFT 21
+#define PDPSHIFT 30
+#define PML4SHIFT 39
 #else
-#define PTXSHIFT        12      // offset of PTX in a linear address
-#define PDXSHIFT        22      // offset of PDX in a linear address
+#define PTXSHIFT 12 // offset of PTX in a linear address
+#define PDXSHIFT 22 // offset of PDX in a linear address
 #endif
 
-#define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
-#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
+#define PGROUNDUP(sz) (((sz) + PGSIZE - 1) & ~(PGSIZE - 1))
+#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE - 1))
 
 // Page table/directory entry flags.
-#define PTE_P           0x001   // Present
-#define PTE_W           0x002   // Writeable
-#define PTE_U           0x004   // User
-#define PTE_PS          0x080   // Page Size
+#define PTE_P 0x001  // Present
+#define PTE_W 0x002  // Writeable
+#define PTE_U 0x004  // User
+#define PTE_PS 0x080 // Page Size
 
 // Address in page table or page directory entry
 #ifdef __x86_64__
-
-#define PTE_ADDR(pte)   ((uint64)(pte) & ~0xFFFULL)
-
-#define PTE_ADDR(pte)   ((uint64)(pte) & ~0xFFF)
-
-#define PTE_FLAGS(pte)  ((uint64)(pte) &  0xFFF)
+#define PTE_ADDR(pte) ((uint64)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint64)(pte) & 0xFFF)
 #else
-#define PTE_ADDR(pte)   ((uint)(pte) & ~0xFFF)
-#define PTE_FLAGS(pte)  ((uint)(pte) &  0xFFF)
+#define PTE_ADDR(pte) ((uint)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint)(pte) & 0xFFF)
 #endif
 
 #ifndef __ASSEMBLER__
 #ifdef __x86_64__
 typedef uint64 pte_t;
-
-
 typedef uint64 pdpe_t;
 typedef uint64 pml4e_t;
-
 #else
 typedef uint pte_t;
 #endif
 
 // Task state segment format
 struct taskstate {
-  uint link;         // Old ts selector
-  uint esp0;         // Stack pointers and segment selectors
-  ushort ss0;        //   after an increase in privilege level
+  uint link;  // Old ts selector
+  uint esp0;  // Stack pointers and segment selectors
+  ushort ss0; //   after an increase in privilege level
   ushort padding1;
   uint *esp1;
   ushort ss1;
@@ -172,10 +169,10 @@ struct taskstate {
   uint *esp2;
   ushort ss2;
   ushort padding3;
-  void *cr3;         // Page directory base
-  uint *eip;         // Saved state from last task switch
+  void *cr3; // Page directory base
+  uint *eip; // Saved state from last task switch
   uint eflags;
-  uint eax;          // More saved state (registers)
+  uint eax; // More saved state (registers)
   uint ecx;
   uint edx;
   uint ebx;
@@ -183,7 +180,7 @@ struct taskstate {
   uint *ebp;
   uint esi;
   uint edi;
-  ushort es;         // Even more saved state (segment selectors)
+  ushort es; // Even more saved state (segment selectors)
   ushort padding4;
   ushort cs;
   ushort padding5;
@@ -197,21 +194,21 @@ struct taskstate {
   ushort padding9;
   ushort ldt;
   ushort padding10;
-  ushort t;          // Trap on task switch
-  ushort iomb;       // I/O map base address
+  ushort t;    // Trap on task switch
+  ushort iomb; // I/O map base address
 };
 
 // Gate descriptors for interrupts and traps
 struct gatedesc {
-  uint off_15_0 : 16;   // low 16 bits of offset in segment
-  uint cs : 16;         // code segment selector
-  uint args : 5;        // # args, 0 for interrupt/trap gates
-  uint rsv1 : 3;        // reserved(should be zero I guess)
-  uint type : 4;        // type(STS_{IG32,TG32})
-  uint s : 1;           // must be 0 (system)
-  uint dpl : 2;         // descriptor(meaning new) privilege level
-  uint p : 1;           // Present
-  uint off_31_16 : 16;  // high bits of offset in segment
+  uint off_15_0 : 16;  // low 16 bits of offset in segment
+  uint cs : 16;        // code segment selector
+  uint args : 5;       // # args, 0 for interrupt/trap gates
+  uint rsv1 : 3;       // reserved(should be zero I guess)
+  uint type : 4;       // type(STS_{IG32,TG32})
+  uint s : 1;          // must be 0 (system)
+  uint dpl : 2;        // descriptor(meaning new) privilege level
+  uint p : 1;          // Present
+  uint off_31_16 : 16; // high bits of offset in segment
 };
 
 // Set up a normal interrupt/trap gate descriptor.
@@ -222,17 +219,17 @@ struct gatedesc {
 // - dpl: Descriptor Privilege Level -
 //        the privilege level required for software to invoke
 //        this interrupt/trap gate explicitly using an int instruction.
-#define SETGATE(gate, istrap, sel, off, d)                \
-{                                                         \
-  (gate).off_15_0 = (uint)(off) & 0xffff;                \
-  (gate).cs = (sel);                                      \
-  (gate).args = 0;                                        \
-  (gate).rsv1 = 0;                                        \
-  (gate).type = (istrap) ? STS_TG32 : STS_IG32;           \
-  (gate).s = 0;                                           \
-  (gate).dpl = (d);                                       \
-  (gate).p = 1;                                           \
-  (gate).off_31_16 = (uint)(off) >> 16;                  \
-}
+#define SETGATE(gate, istrap, sel, off, d)                                     \
+  {                                                                            \
+    (gate).off_15_0 = (uint)(off) & 0xffff;                                    \
+    (gate).cs = (sel);                                                         \
+    (gate).args = 0;                                                           \
+    (gate).rsv1 = 0;                                                           \
+    (gate).type = (istrap) ? STS_TG32 : STS_IG32;                              \
+    (gate).s = 0;                                                              \
+    (gate).dpl = (d);                                                          \
+    (gate).p = 1;                                                              \
+    (gate).off_31_16 = (uint)(off) >> 16;                                      \
+  }
 
 #endif

--- a/types.h
+++ b/types.h
@@ -1,24 +1,13 @@
-typedef unsigned int   uint;
+#pragma once
+
+typedef unsigned int uint;
 typedef unsigned short ushort;
-typedef unsigned char  uchar;
+typedef unsigned char uchar;
 typedef unsigned long long uint64;
-
-#ifdef __x86_64__
-typedef uint64 pde_t;
-#else
-typedef uint pde_t;
-
-#endif
-
-
-#endif
-
-
 typedef unsigned long uintptr_t;
 
 #ifdef __x86_64__
-typedef unsigned long uint64;
-
-
-
-
+typedef unsigned long long pde_t;
+#else
+typedef unsigned int pde_t;
+#endif

--- a/x86.h
+++ b/x86.h
@@ -1,71 +1,54 @@
 // Routines to let C code use special x86 instructions.
 
-static inline uchar
-inb(ushort port)
-{
+static inline uchar inb(ushort port) {
   uchar data;
 
-  asm volatile("in %1,%0" : "=a" (data) : "d" (port));
+  asm volatile("in %1,%0" : "=a"(data) : "d"(port));
   return data;
 }
 
-static inline void
-insl(int port, void *addr, int cnt)
-{
-  asm volatile("cld; rep insl" :
-               "=D" (addr), "=c" (cnt) :
-               "d" (port), "0" (addr), "1" (cnt) :
-               "memory", "cc");
+static inline void insl(int port, void *addr, int cnt) {
+  asm volatile("cld; rep insl"
+               : "=D"(addr), "=c"(cnt)
+               : "d"(port), "0"(addr), "1"(cnt)
+               : "memory", "cc");
 }
 
-static inline void
-outb(ushort port, uchar data)
-{
-  asm volatile("out %0,%1" : : "a" (data), "d" (port));
+static inline void outb(ushort port, uchar data) {
+  asm volatile("out %0,%1" : : "a"(data), "d"(port));
 }
 
-static inline void
-outw(ushort port, ushort data)
-{
-  asm volatile("out %0,%1" : : "a" (data), "d" (port));
+static inline void outw(ushort port, ushort data) {
+  asm volatile("out %0,%1" : : "a"(data), "d"(port));
 }
 
-static inline void
-outsl(int port, const void *addr, int cnt)
-{
-  asm volatile("cld; rep outsl" :
-               "=S" (addr), "=c" (cnt) :
-               "d" (port), "0" (addr), "1" (cnt) :
-               "cc");
+static inline void outsl(int port, const void *addr, int cnt) {
+  asm volatile("cld; rep outsl"
+               : "=S"(addr), "=c"(cnt)
+               : "d"(port), "0"(addr), "1"(cnt)
+               : "cc");
 }
 
-static inline void
-stosb(void *addr, int data, int cnt)
-{
-  asm volatile("cld; rep stosb" :
-               "=D" (addr), "=c" (cnt) :
-               "0" (addr), "1" (cnt), "a" (data) :
-               "memory", "cc");
+static inline void stosb(void *addr, int data, int cnt) {
+  asm volatile("cld; rep stosb"
+               : "=D"(addr), "=c"(cnt)
+               : "0"(addr), "1"(cnt), "a"(data)
+               : "memory", "cc");
 }
 
-static inline void
-stosl(void *addr, int data, int cnt)
-{
-  asm volatile("cld; rep stosl" :
-               "=D" (addr), "=c" (cnt) :
-               "0" (addr), "1" (cnt), "a" (data) :
-               "memory", "cc");
+static inline void stosl(void *addr, int data, int cnt) {
+  asm volatile("cld; rep stosl"
+               : "=D"(addr), "=c"(cnt)
+               : "0"(addr), "1"(cnt), "a"(data)
+               : "memory", "cc");
 }
 
 struct segdesc;
 
-static inline void
-lgdt(struct segdesc *p, int size)
-{
+static inline void lgdt(struct segdesc *p, int size) {
   volatile ushort pd[3];
 
-  pd[0] = size-1;
-
+  pd[0] = size - 1;
 #ifdef __x86_64__
   pd[1] = (uint64)p;
   pd[2] = (uint64)p >> 16;
@@ -74,22 +57,15 @@ lgdt(struct segdesc *p, int size)
   pd[2] = (uint)p >> 16;
 #endif
 
-  pd[1] = (uintptr_t)p;
-  pd[2] = (uintptr_t)p >> 16;
-
-
-  asm volatile("lgdt (%0)" : : "r" (pd));
+  asm volatile("lgdt (%0)" : : "r"(pd));
 }
 
 struct gatedesc;
 
-static inline void
-lidt(struct gatedesc *p, int size)
-{
+static inline void lidt(struct gatedesc *p, int size) {
   volatile ushort pd[3];
 
-  pd[0] = size-1;
-
+  pd[0] = size - 1;
 #ifdef __x86_64__
   pd[1] = (uint64)p;
   pd[2] = (uint64)p >> 16;
@@ -98,98 +74,67 @@ lidt(struct gatedesc *p, int size)
   pd[2] = (uint)p >> 16;
 #endif
 
-  pd[1] = (uintptr_t)p;
-  pd[2] = (uintptr_t)p >> 16;
-
-
-  asm volatile("lidt (%0)" : : "r" (pd));
+  asm volatile("lidt (%0)" : : "r"(pd));
 }
 
-static inline void
-ltr(ushort sel)
-{
-  asm volatile("ltr %0" : : "r" (sel));
-}
+static inline void ltr(ushort sel) { asm volatile("ltr %0" : : "r"(sel)); }
 
-static inline uint
-readeflags(void)
-{
+static inline uint readeflags(void) {
   uint eflags;
-  asm volatile("pushfl; popl %0" : "=r" (eflags));
+  asm volatile("pushfl; popl %0" : "=r"(eflags));
   return eflags;
 }
 
-static inline void
-loadgs(ushort v)
-{
-  asm volatile("movw %0, %%gs" : : "r" (v));
+static inline void loadgs(ushort v) {
+  asm volatile("movw %0, %%gs" : : "r"(v));
 }
 
-static inline void
-cli(void)
-{
-  asm volatile("cli");
-}
+static inline void cli(void) { asm volatile("cli"); }
 
-static inline void
-sti(void)
-{
-  asm volatile("sti");
-}
+static inline void sti(void) { asm volatile("sti"); }
 
-static inline uint
-xchg(volatile uint *addr, uint newval)
-{
+static inline uint xchg(volatile uint *addr, uint newval) {
   uint result;
 
   // The + in "+m" denotes a read-modify-write operand.
-  asm volatile("lock; xchgl %0, %1" :
-               "+m" (*addr), "=a" (result) :
-               "1" (newval) :
-               "cc");
+  asm volatile("lock; xchgl %0, %1"
+               : "+m"(*addr), "=a"(result)
+               : "1"(newval)
+               : "cc");
   return result;
 }
 
 #ifdef __x86_64__
-static inline uint64
-rcr2(void)
-{
+static inline uint64 rcr2(void) {
   uint64 val;
-  asm volatile("movq %%cr2,%0" : "=r" (val));
+  asm volatile("movq %%cr2,%0" : "=r"(val));
   return val;
 }
 
-static inline void
-lcr3(uint64 val)
-{
-  asm volatile("movq %0,%%cr3" : : "r" (val));
+static inline void lcr3(uint64 val) {
+  asm volatile("movq %0,%%cr3" : : "r"(val));
 }
 #else
-static inline uint
-rcr2(void)
-{
+static inline uint rcr2(void) {
   uint val;
-  asm volatile("movl %%cr2,%0" : "=r" (val));
+  asm volatile("movl %%cr2,%0" : "=r"(val));
   return val;
 }
 
-static inline void
-lcr3(uint val)
-{
-  asm volatile("movl %0,%%cr3" : : "r" (val));
+static inline void lcr3(uint val) {
+  asm volatile("movl %0,%%cr3" : : "r"(val));
 }
 #endif
 
-//PAGEBREAK: 36
-// Layout of the trap frame built on the stack by the
-// hardware and by trapasm.S, and passed to trap().
-#ifndef __x86_64__
+// PAGEBREAK: 36
+//  Layout of the trap frame built on the stack by the
+//  hardware and by trapasm.S, and passed to trap().
 struct trapframe {
   // registers as pushed by pusha
   uint edi;
   uint esi;
   uint ebp;
-  uint oesp;      // useless & ignored
+  uint oesp; // useless & ignored
   uint ebx;
   uint edx;
   uint ecx;
@@ -218,29 +163,3 @@ struct trapframe {
   ushort ss;
   ushort padding6;
 };
-#else
-struct trapframe {
-  uint64 r15;
-  uint64 r14;
-  uint64 r13;
-  uint64 r12;
-  uint64 r11;
-  uint64 r10;
-  uint64 r9;
-  uint64 r8;
-  uint64 rdi;
-  uint64 rsi;
-  uint64 rbp;
-  uint64 rbx;
-  uint64 rdx;
-  uint64 rcx;
-  uint64 rax;
-  uint64 trapno;
-  uint64 err;
-  uint64 rip;
-  uint64 cs;
-  uint64 eflags;
-  uint64 rsp;
-  uint64 ss;
-};
-#endif


### PR DESCRIPTION
## Summary
- clean up type definitions for portability
- fix mmu.h and memory macros
- restore x86.h from before broken merges
- run clang-format on modified headers

## Testing
- `make -j$(nproc)`