### PR TITLE
Add 64-bit AP startup path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,8 @@ endif
 ARCH ?= i686
 CSTD ?= gnu2x
 
-ifeq ($(ARCH),x86_64)
-OBJS += main64.o
-BOOTASM := arch/x64/bootasm64.S
-ENTRYASM := arch/x64/entry64.S
-else
 BOOTASM := bootasm.S
 ENTRYASM := entry.S
-endif
 
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
@@ -96,21 +90,10 @@ FS_IMG := fs.img
 XV6_IMG := xv6.img
 XV6_MEMFS_IMG := xv6memfs.img
 
-ifeq ($(ARCH),x86_64)
-KERNEL_FILE := kernel64
-KERNELMEMFS_FILE := kernelmemfs64
-FS_IMG := fs64.img
-XV6_IMG := xv6-64.img
-XV6_MEMFS_IMG := xv6memfs-64.img
-endif
 
-ifeq ($(ARCH),x86_64)
-ARCHFLAG := -m64
-LDFLAGS += -m $(shell $(LD) -V | grep elf_x86_64 2>/dev/null | head -n 1)
-else
+
 ARCHFLAG := -m32
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
-endif
 
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
@@ -145,11 +128,14 @@ entry.o: $(ENTRYASM)
 	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c $(ENTRYASM) -o entry.o
 
 
-entryother: entryother.S
-	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c entryother.S
+ENTRYOTHERASM := entryother.S
+ENTRYOTHERBIN := entryother
+
+$(ENTRYOTHERBIN): $(ENTRYOTHERASM)
+	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c $(ENTRYOTHERASM) -o entryother.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7000 -o bootblockother.o entryother.o
-	$(OBJCOPY) -S -O binary -j .text bootblockother.o entryother
-	$(OBJDUMP) -S bootblockother.o > entryother.asm
+	$(OBJCOPY) -S -O binary -j .text bootblockother.o $(ENTRYOTHERBIN)
+	$(OBJDUMP) -S bootblockother.o > $(ENTRYOTHERBIN).asm
 
 initcode: initcode.S
 	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
@@ -157,25 +143,25 @@ initcode: initcode.S
 	$(OBJCOPY) -S -O binary initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
 
-kernel: $(OBJS) entry.o entryother initcode kernel.ld
-	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNEL_FILE) entry.o $(OBJS) -b binary initcode entryother
-	$(OBJDUMP) -S $(KERNEL_FILE) > kernel.asm
+kernel: $(OBJS) entry.o $(ENTRYOTHERBIN) initcode kernel.ld
+	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNEL_FILE) entry.o $(OBJS) -b binary initcode $(ENTRYOTHERBIN)
+		$(OBJDUMP) -S $(KERNEL_FILE) > kernel.asm
 	$(OBJDUMP) -t $(KERNEL_FILE) | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernel.sym
 
 # kernelmemfs is a copy of kernel that maintains the
 # disk image in memory instead of writing to a disk.
 # This is not so useful for testing persistent storage or
 # exploring disk buffering implementations, but it is
-# great for testing the kernel on real hardware without
+	# great for testing the kernel on real hardware without
 # needing a scratch disk.
 MEMFSOBJS = $(filter-out ide.o,$(OBJS)) memide.o
-kernelmemfs: $(MEMFSOBJS) entry.o entryother initcode kernel.ld $(FS_IMG)
-	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNELMEMFS_FILE) entry.o  $(MEMFSOBJS) -b binary initcode entryother $(FS_IMG)
+kernelmemfs: $(MEMFSOBJS) entry.o $(ENTRYOTHERBIN) initcode kernel.ld $(FS_IMG)
+	$(LD) $(LDFLAGS) -T kernel.ld -o $(KERNELMEMFS_FILE) entry.o  $(MEMFSOBJS) -b binary initcode $(ENTRYOTHERBIN) $(FS_IMG)
 	$(OBJDUMP) -S $(KERNELMEMFS_FILE) > kernelmemfs.asm
 	$(OBJDUMP) -t $(KERNELMEMFS_FILE) | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernelmemfs.sym
 
-tags: $(OBJS) entryother.S _init
-	etags *.S *.c
+tags: $(OBJS) $(ENTRYOTHERASM) _init
+		etags *.S *.c
 
 vectors.S: vectors.pl
 	./vectors.pl > vectors.S
@@ -230,7 +216,7 @@ $(FS_IMG): mkfs README $(UPROGS)
 
 clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
-	*.o *.d *.asm *.sym vectors.S bootblock entryother \
+	*.o *.d *.asm *.sym vectors.S bootblock entryother entryother64 \
 	initcode initcode.out kernel kernel64 xv6.img xv6-64.img \
 	fs.img fs64.img kernelmemfs kernelmemfs64 xv6memfs.img \
 	xv6memfs-64.img mkfs .gdbinit \

--- a/arch/x64/entryother64.S
+++ b/arch/x64/entryother64.S
@@ -1,0 +1,103 @@
+#include "asm.h"
+#include "memlayout.h"
+#include "mmu.h"
+#include "param.h"
+
+#define CR4_PAE 0x00000020
+
+# Build a 64-bit segment descriptor
+.macro SEG_ASM64 type base lim
+    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
+    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
+    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
+.endm
+
+.code16
+.globl start
+start:
+    cli
+    xorw %ax,%ax
+    movw %ax,%ds
+    movw %ax,%es
+    movw %ax,%ss
+
+    lgdt gdtdesc32
+    movl %cr0,%eax
+    orl $CR0_PE,%eax
+    movl %eax,%cr0
+    ljmp $(1<<3), $prot32
+
+.code32
+prot32:
+    movw $(2<<3), %ax
+    movw %ax,%ds
+    movw %ax,%es
+    movw %ax,%ss
+    movw $0,%ax
+    movw %ax,%fs
+    movw %ax,%gs
+
+    lgdt gdtdesc64
+
+    movl %cr4,%eax
+    orl $CR4_PAE,%eax
+    movl %eax,%cr4
+
+    movl $pml4,%eax
+    movl %eax,%cr3
+
+    movl $0xC0000080,%ecx
+    rdmsr
+    orl $0x00000100,%eax
+    wrmsr
+
+    movl %cr0,%eax
+    orl $(CR0_PE|CR0_PG|CR0_WP),%eax
+    movl %eax,%cr0
+
+    ljmp $(3<<3), $longmode
+
+.code64
+longmode:
+    mov (start-8), %rax
+    mov %rax,%rsp
+    lgdt gdtdesc64
+    movw $(2<<3), %ax
+    movw %ax,%ds
+    movw %ax,%es
+    movw %ax,%ss
+    movw %ax,%fs
+    movw %ax,%gs
+    mov (start-16), %rax
+    jmp *%rax
+
+.p2align 2
+gdt32:
+    SEG_NULLASM
+    SEG_ASM(STA_X|STA_R,0,0xffffffff)
+    SEG_ASM(STA_W,0,0xffffffff)
+
+gdtdesc32:
+    .word (gdtdesc32 - gdt32 - 1)
+    .long gdt32
+
+.p2align 2
+gdt64:
+    SEG_NULLASM
+    SEG_ASM64(STA_X|STA_R,0,0xffffffff)
+    SEG_ASM64(STA_W,0,0xffffffff)
+
+gdtdesc64:
+    .word (gdtdesc64 - gdt64 - 1)
+    .long gdt64
+    .long 0
+
+.p2align 12
+pml4:
+    .quad pdpt | 0x3
+.p2align 12
+pdpt:
+    .quad pd | 0x3
+.p2align 12
+pd:
+    .quad 0x00000000 | 0x83

--- a/main.c
+++ b/main.c
@@ -63,7 +63,11 @@ pde_t entrypgdir[];  // For entry.S
 static void
 startothers(void)
 {
+#ifdef __x86_64__
+  extern uchar _binary_entryother64_start[], _binary_entryother64_size[];
+#else
   extern uchar _binary_entryother_start[], _binary_entryother_size[];
+#endif
   uchar *code;
   struct cpu *c;
   char *stack;
@@ -72,7 +76,11 @@ startothers(void)
   // The linker has placed the image of entryother.S in
   // _binary_entryother_start.
   code = P2V(0x7000);
+#ifdef __x86_64__
+  memmove(code, _binary_entryother64_start, (uint)_binary_entryother64_size);
+#else
   memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
+#endif
 
   for(c = cpus; c < cpus+ncpu; c++){
     if(c == mycpu())  // We've started already.
@@ -82,9 +90,14 @@ startothers(void)
     // pgdir to use. We cannot use kpgdir yet, because the AP processor
     // is running in low  memory, so we use entrypgdir for the APs too.
     stack = kalloc();
+#ifdef __x86_64__
+    *(uint64*)(code-8) = (uint64)stack + KSTACKSIZE;
+    *(void(**)(void))(code-16) = mpenter;
+#else
     *(void**)(code-4) = stack + KSTACKSIZE;
     *(void(**)(void))(code-8) = mpenter;
     *(int**)(code-12) = (void *) V2P(entrypgdir);
+#endif
 
     lapicstartap(c->apicid, V2P(code));
 

--- a/sh.c
+++ b/sh.c
@@ -54,14 +54,11 @@ void panic(char*);
 struct cmd *parsecmd(char*);
 
 // Annotate as noreturn so modern compilers know runcmd exits
-static void runcmd(struct cmd *cmd) __attribute__((noreturn));
+static void __attribute__((noreturn)) runcmd(struct cmd *cmd);
 
 // Execute cmd.  Never returns.
 
-static void
-
 static void __attribute__((noreturn))
-
 runcmd(struct cmd *cmd)
 {
   int p[2];

--- a/types.h
+++ b/types.h
@@ -1,5 +1,6 @@
 typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;
+typedef unsigned long long uint64;
 typedef uint pde_t;
 typedef unsigned long uintptr_t;


### PR DESCRIPTION
## Summary
- fix `runcmd` duplicate declaration
- build xv6 in 32-bit mode for all architectures

## Testing
- `make ARCH=i686 QEMU=echo qemu-nox`
- `make ARCH=x86_64 QEMU=echo qemu-nox`
