### PR TITLE
Add exokernel API headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ entryother
 initcode
 initcode.out
 kernel
+!kernel/
 kernelmemfs
 mkfs
 .gdbinit

--- a/defs.h
+++ b/defs.h
@@ -16,188 +16,193 @@ struct sleeplock;
 struct stat;
 struct superblock;
 
+#include "kernel/exo_cpu.h"
+#include "kernel/exo_disk.h"
+#include "kernel/exo_ipc.h"
+#include "kernel/exo_mem.h"
+
 // bio.c
-void            binit(void);
-struct buf*     bread(uint, uint);
-void            brelse(struct buf*);
-void            bwrite(struct buf*);
+void binit(void);
+struct buf *bread(uint, uint);
+void brelse(struct buf *);
+void bwrite(struct buf *);
 
 // console.c
-void            consoleinit(void);
-void            cprintf(char*, ...);
-void            consoleintr(int(*)(void));
-void            panic(char*) __attribute__((noreturn));
+void consoleinit(void);
+void cprintf(char *, ...);
+void consoleintr(int (*)(void));
+void panic(char *) __attribute__((noreturn));
 
 // exec.c
-int             exec(char*, char**);
+int exec(char *, char **);
 
 // file.c
-struct file*    filealloc(void);
-void            fileclose(struct file*);
-struct file*    filedup(struct file*);
-void            fileinit(void);
-int             fileread(struct file*, char*, int n);
-int             filestat(struct file*, struct stat*);
-int             filewrite(struct file*, char*, int n);
+struct file *filealloc(void);
+void fileclose(struct file *);
+struct file *filedup(struct file *);
+void fileinit(void);
+int fileread(struct file *, char *, int n);
+int filestat(struct file *, struct stat *);
+int filewrite(struct file *, char *, int n);
 
 // fs.c
-void            readsb(int dev, struct superblock *sb);
-int             dirlink(struct inode*, char*, uint);
-struct inode*   dirlookup(struct inode*, char*, uint*);
-struct inode*   ialloc(uint, short);
-struct inode*   idup(struct inode*);
-void            iinit(int dev);
-void            ilock(struct inode*);
-void            iput(struct inode*);
-void            iunlock(struct inode*);
-void            iunlockput(struct inode*);
-void            iupdate(struct inode*);
-int             namecmp(const char*, const char*);
-struct inode*   namei(char*);
-struct inode*   nameiparent(char*, char*);
-int             readi(struct inode*, char*, uint, uint);
-void            stati(struct inode*, struct stat*);
-int             writei(struct inode*, char*, uint, uint);
+void readsb(int dev, struct superblock *sb);
+int dirlink(struct inode *, char *, uint);
+struct inode *dirlookup(struct inode *, char *, uint *);
+struct inode *ialloc(uint, short);
+struct inode *idup(struct inode *);
+void iinit(int dev);
+void ilock(struct inode *);
+void iput(struct inode *);
+void iunlock(struct inode *);
+void iunlockput(struct inode *);
+void iupdate(struct inode *);
+int namecmp(const char *, const char *);
+struct inode *namei(char *);
+struct inode *nameiparent(char *, char *);
+int readi(struct inode *, char *, uint, uint);
+void stati(struct inode *, struct stat *);
+int writei(struct inode *, char *, uint, uint);
 
 // ide.c
-void            ideinit(void);
-void            ideintr(void);
-void            iderw(struct buf*);
+void ideinit(void);
+void ideintr(void);
+void iderw(struct buf *);
 
 // ioapic.c
-void            ioapicenable(int irq, int cpu);
-extern uchar    ioapicid;
-void            ioapicinit(void);
+void ioapicenable(int irq, int cpu);
+extern uchar ioapicid;
+void ioapicinit(void);
 
 // kalloc.c
-char*           kalloc(void);
-void            kfree(char*);
-void            kinit1(void*, void*);
-void            kinit2(void*, void*);
+char *kalloc(void);
+void kfree(char *);
+void kinit1(void *, void *);
+void kinit2(void *, void *);
 
 // kbd.c
-void            kbdintr(void);
+void kbdintr(void);
 
 // lapic.c
-void            cmostime(struct rtcdate *r);
-int             lapicid(void);
-extern volatile uint*    lapic;
-void            lapiceoi(void);
-void            lapicinit(void);
-void            lapicstartap(uchar, uint);
-void            microdelay(int);
+void cmostime(struct rtcdate *r);
+int lapicid(void);
+extern volatile uint *lapic;
+void lapiceoi(void);
+void lapicinit(void);
+void lapicstartap(uchar, uint);
+void microdelay(int);
 
 // log.c
-void            initlog(int dev);
-void            log_write(struct buf*);
-void            begin_op();
-void            end_op();
+void initlog(int dev);
+void log_write(struct buf *);
+void begin_op();
+void end_op();
 
 // mp.c
-extern int      ismp;
-void            mpinit(void);
+extern int ismp;
+void mpinit(void);
 
 // picirq.c
-void            picenable(int);
-void            picinit(void);
+void picenable(int);
+void picinit(void);
 
 // pipe.c
-int             pipealloc(struct file**, struct file**);
-void            pipeclose(struct pipe*, int);
-int             piperead(struct pipe*, char*, int);
-int             pipewrite(struct pipe*, char*, int);
+int pipealloc(struct file **, struct file **);
+void pipeclose(struct pipe *, int);
+int piperead(struct pipe *, char *, int);
+int pipewrite(struct pipe *, char *, int);
 
-//PAGEBREAK: 16
-// proc.c
-int             cpuid(void);
-void            exit(void);
-int             fork(void);
-int             growproc(int);
-int             kill(int);
-struct cpu*     mycpu(void);
-struct proc*    myproc();
-void            pinit(void);
-void            procdump(void);
-void            scheduler(void) __attribute__((noreturn));
-void            sched(void);
-void            setproc(struct proc*);
-void            sleep(void*, struct spinlock*);
-void            userinit(void);
-int             wait(void);
-void            wakeup(void*);
-void            yield(void);
+// PAGEBREAK: 16
+//  proc.c
+int cpuid(void);
+void exit(void);
+int fork(void);
+int growproc(int);
+int kill(int);
+struct cpu *mycpu(void);
+struct proc *myproc();
+void pinit(void);
+void procdump(void);
+void scheduler(void) __attribute__((noreturn));
+void sched(void);
+void setproc(struct proc *);
+void sleep(void *, struct spinlock *);
+void userinit(void);
+int wait(void);
+void wakeup(void *);
+void yield(void);
 
 // swtch.S
-void            swtch(context_t**, context_t*);
+void swtch(context_t **, context_t *);
 
 // spinlock.c
-void            acquire(struct spinlock*);
-void            getcallerpcs(void*, uint*);
-int             holding(struct spinlock*);
-void            initlock(struct spinlock*, char*);
-void            release(struct spinlock*);
-void            pushcli(void);
-void            popcli(void);
+void acquire(struct spinlock *);
+void getcallerpcs(void *, uint *);
+int holding(struct spinlock *);
+void initlock(struct spinlock *, char *);
+void release(struct spinlock *);
+void pushcli(void);
+void popcli(void);
 
 // sleeplock.c
-void            acquiresleep(struct sleeplock*);
-void            releasesleep(struct sleeplock*);
-int             holdingsleep(struct sleeplock*);
-void            initsleeplock(struct sleeplock*, char*);
+void acquiresleep(struct sleeplock *);
+void releasesleep(struct sleeplock *);
+int holdingsleep(struct sleeplock *);
+void initsleeplock(struct sleeplock *, char *);
 
 // string.c
-int             memcmp(const void*, const void*, uint);
-void*           memmove(void*, const void*, uint);
-void*           memset(void*, int, uint);
-char*           safestrcpy(char*, const char*, int);
-int             strlen(const char*);
-int             strncmp(const char*, const char*, uint);
-char*           strncpy(char*, const char*, int);
+int memcmp(const void *, const void *, uint);
+void *memmove(void *, const void *, uint);
+void *memset(void *, int, uint);
+char *safestrcpy(char *, const char *, int);
+int strlen(const char *);
+int strncmp(const char *, const char *, uint);
+char *strncpy(char *, const char *, int);
 
 // syscall.c
-int             argint(int, int*);
-int             argptr(int, char**, int);
-int             argstr(int, char**);
-int             fetchint(uint, int*);
-int             fetchstr(uint, char**);
-void            syscall(void);
+int argint(int, int *);
+int argptr(int, char **, int);
+int argstr(int, char **);
+int fetchint(uint, int *);
+int fetchstr(uint, char **);
+void syscall(void);
 
 // timer.c
-void            timerinit(void);
+void timerinit(void);
 
 // trap.c
-void            idtinit(void);
-extern uint     ticks;
-void            tvinit(void);
+void idtinit(void);
+extern uint ticks;
+void tvinit(void);
 extern struct spinlock tickslock;
 
 // uart.c
-void            uartinit(void);
-void            uartintr(void);
-void            uartputc(int);
+void uartinit(void);
+void uartintr(void);
+void uartputc(int);
 
 // vm.c
-void            seginit(void);
-void            kvmalloc(void);
-pde_t*          setupkvm(void);
+void seginit(void);
+void kvmalloc(void);
+pde_t *setupkvm(void);
 #ifdef __x86_64__
-pml4e_t*        setupkvm64(void);
+pml4e_t *setupkvm64(void);
 #endif
-char*           uva2ka(pde_t*, char*);
-int             allocuvm(pde_t*, uint, uint);
-int             deallocuvm(pde_t*, uint, uint);
-void            freevm(pde_t*);
-void            inituvm(pde_t*, char*, uint);
-int             loaduvm(pde_t*, char*, struct inode*, uint, uint);
-pde_t*          copyuvm(pde_t*, uint);
-void            switchuvm(struct proc*);
-void            switchkvm(void);
+char *uva2ka(pde_t *, char *);
+int allocuvm(pde_t *, uint, uint);
+int deallocuvm(pde_t *, uint, uint);
+void freevm(pde_t *);
+void inituvm(pde_t *, char *, uint);
+int loaduvm(pde_t *, char *, struct inode *, uint, uint);
+pde_t *copyuvm(pde_t *, uint);
+void switchuvm(struct proc *);
+void switchkvm(void);
 #ifdef __x86_64__
-int             copyout(pde_t*, uint64, void*, uint);
+int copyout(pde_t *, uint64, void *, uint);
 #else
-int             copyout(pde_t*, uint, void*, uint);
+int copyout(pde_t *, uint, void *, uint);
 #endif
-void            clearpteu(pde_t *pgdir, char *uva);
+void clearpteu(pde_t *pgdir, char *uva);
 
 // number of elements in fixed-size array
-#define NELEM(x) (sizeof(x)/sizeof((x)[0]))
+#define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/kernel/exo_cpu.h
+++ b/kernel/exo_cpu.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "exo_mem.h"
+#include <stdint.h>
+
+int exo_yield_to(cap_t target);

--- a/kernel/exo_disk.h
+++ b/kernel/exo_disk.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "exo_mem.h"
+#include <stdint.h>
+
+int exo_read_disk(cap_t cap, void *dst, uint64_t off, uint64_t n);
+int exo_write_disk(cap_t cap, const void *src, uint64_t off, uint64_t n);

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "exo_mem.h"
+#include <stdint.h>
+
+int exo_send(cap_t dest, const void *buf, uint64_t len);
+int exo_recv(cap_t src, void *buf, uint64_t len);

--- a/kernel/exo_mem.h
+++ b/kernel/exo_mem.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+
+typedef uint64_t cap_t;
+
+cap_t exo_alloc_page(void);
+int exo_bind_page(cap_t cap, void *va, int perm);
+int exo_unbind_page(void *va);


### PR DESCRIPTION
## Summary
- provide new exokernel API headers
- expose cap_t typedef and function prototypes
- reference headers from defs.h
- add clang-format configuration
- update `.gitignore` to allow committing the new `kernel` directory

## Testing
- `clang-format -i kernel/exo_mem.h kernel/exo_cpu.h kernel/exo_disk.h kernel/exo_ipc.h defs.h`
