### PR TITLE
Add exo_pctr_transfer trap mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,11 @@ OBJS = \
 	sysfile.o\
 	sysproc.o\
 	trapasm.o\
-	trap.o\
-	uart.o\
-	vectors.o\
+        trap.o\
+        uart.o\
+        vectors.o\
         vm.o\
+        exo.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += mmu64.o

--- a/defs.h
+++ b/defs.h
@@ -170,6 +170,7 @@ void            idtinit(void);
 extern uint     ticks;
 void            tvinit(void);
 extern struct spinlock tickslock;
+void            exo_pctr_transfer(struct trapframe *);
 
 // uart.c
 void            uartinit(void);

--- a/exo.c
+++ b/exo.c
@@ -1,0 +1,20 @@
+#include "defs.h"
+#include "param.h"
+#include "proc.h"
+#include "spinlock.h"
+#include "types.h"
+#include "x86.h"
+
+void exo_pctr_transfer(struct trapframe *tf) {
+  uint cap = tf->eax;
+  struct proc *p;
+
+  acquire(&ptable.lock);
+  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+    if (p->state != UNUSED && p->pctr_cap == cap) {
+      p->pctr_signal++;
+      break;
+    }
+  }
+  release(&ptable.lock);
+}

--- a/proc.c
+++ b/proc.c
@@ -15,6 +15,7 @@ struct {
 static struct proc *initproc;
 
 int nextpid = 1;
+static uint nextpctr_cap = 1;
 extern void forkret(void);
 extern void trapret(void);
 
@@ -88,6 +89,8 @@ allocproc(void)
 found:
   p->state = EMBRYO;
   p->pid = nextpid++;
+  p->pctr_cap = nextpctr_cap++;
+  p->pctr_signal = 0;
 
   release(&ptable.lock);
 

--- a/proc.h
+++ b/proc.h
@@ -71,6 +71,8 @@ struct proc {
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
+  uint pctr_cap;               // Capability for exo_pctr_transfer
+  volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
 
 // Process memory is laid out contiguously, low addresses first:

--- a/trap.c
+++ b/trap.c
@@ -22,6 +22,7 @@ tvinit(void)
   for(i = 0; i < 256; i++)
     SETGATE(idt[i], 0, SEG_KCODE<<3, vectors[i], 0);
   SETGATE(idt[T_SYSCALL], 1, SEG_KCODE<<3, vectors[T_SYSCALL], DPL_USER);
+  SETGATE(idt[T_PCTR_TRANSFER], 1, SEG_KCODE<<3, vectors[T_PCTR_TRANSFER], DPL_USER);
 
   initlock(&tickslock, "time");
 }
@@ -76,6 +77,9 @@ trap(struct trapframe *tf)
     cprintf("cpu%d: spurious interrupt at %x:%x\n",
             cpuid(), tf->cs, tf->eip);
     lapiceoi();
+    break;
+  case T_PCTR_TRANSFER:
+    exo_pctr_transfer(tf);
     break;
 
   //PAGEBREAK: 13

--- a/traps.h
+++ b/traps.h
@@ -25,6 +25,7 @@
 // These are arbitrarily chosen, but with care not to overlap
 // processor defined exceptions or interrupt vectors.
 #define T_SYSCALL       64      // system call
+#define T_PCTR_TRANSFER 65      // exo_pctr_transfer trap
 #define T_DEFAULT      500      // catchall
 
 #define T_IRQ0          32      // IRQ 0 corresponds to int T_IRQ

--- a/user.h
+++ b/user.h
@@ -23,6 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int exo_pctr_transfer(int cap);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/usys.S
+++ b/usys.S
@@ -38,3 +38,17 @@ SYSCALL(getpid)
 SYSCALL(sbrk)
 SYSCALL(sleep)
 SYSCALL(uptime)
+
+#ifndef __x86_64__
+  .globl exo_pctr_transfer
+exo_pctr_transfer:
+  movl 4(%esp), %eax
+  int $T_PCTR_TRANSFER
+  ret
+#else
+  .globl exo_pctr_transfer
+exo_pctr_transfer:
+  movq %rdi, %rax
+  int $T_PCTR_TRANSFER
+  ret
+#endif


### PR DESCRIPTION
## Summary
- add `exo_pctr_transfer` trap number
- track per-process capability and signal counter
- allocate capabilities on process creation
- implement `exo_pctr_transfer` handler
- expose `exo_pctr_transfer` to userspace via new trap stub

## Testing
- `clang-format -i exo.c`
