### PR TITLE
Fix types.h cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ OBJS += swtch.o
 
 BOOTASM := bootasm.S
 ENTRYASM := entry.S
+endif
 
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
@@ -107,7 +108,7 @@ XV6_MEMFS_IMG := xv6memfs.img
 ARCHFLAG := -m32
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD)
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I.
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide
 

--- a/stdint.h
+++ b/stdint.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef __x86_64__
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long int64_t;
+typedef unsigned long uint64_t;
+#else
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+#endif

--- a/types.h
+++ b/types.h
@@ -1,18 +1,16 @@
 #pragma once
 
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char  uchar;
-typedef unsigned long long uint64;
-typedef uint pde_t;
+#include <stdint.h>
 
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
+typedef uint8_t  uchar;
+typedef uint16_t ushort;
+typedef uint32_t uint;
+typedef uint64_t uint64;
 
-typedef unsigned long uintptr_t;
-
-#ifdef __x86_64__i
-typedef unsigned long long pde_t;
+#ifdef __x86_64__
+typedef uint64_t pde_t;
+typedef uint64_t uintptr_t;
 #else
-typedef unsigned int pde_t;
+typedef uint32_t pde_t;
+typedef uint32_t uintptr_t;
 #endif


### PR DESCRIPTION
## Summary
- deduplicate typedefs in `types.h`
- standardize types on `<stdint.h>` definitions
- fix `__x86_64__` conditional
- define `uintptr_t` for 32 and 64-bit builds
- add local `stdint.h` and compile without host headers
- close missing `endif` in `Makefile`

## Testing
- `make clean`
- `make`
