### PR TITLE
Switch to C2x noreturn attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
+endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000

--- a/defs.h
+++ b/defs.h
@@ -26,7 +26,7 @@ void            bwrite(struct buf*);
 void            consoleinit(void);
 void            cprintf(char*, ...);
 void            consoleintr(int(*)(void));
-void            panic(char*) __attribute__((noreturn));
+[[noreturn]] void panic(char*);
 
 // exec.c
 int             exec(char*, char**);
@@ -118,7 +118,7 @@ struct cpu*     mycpu(void);
 struct proc*    myproc();
 void            pinit(void);
 void            procdump(void);
-void            scheduler(void) __attribute__((noreturn));
+[[noreturn]] void scheduler(void);
 void            sched(void);
 void            setproc(struct proc*);
 void            sleep(void*, struct spinlock*);

--- a/user.h
+++ b/user.h
@@ -3,7 +3,7 @@ struct rtcdate;
 
 // system calls
 int fork(void);
-int exit(void) __attribute__((noreturn));
+[[noreturn]] int exit(void);
 int wait(void);
 int pipe(int*);
 int write(int, const void*, int);


### PR DESCRIPTION
## Summary
- use `[[noreturn]]` in prototypes
- close conditional block in Makefile

## Testing
- `make clean`
- `make kernel`