### PR TITLE
Add qemuless fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJS = \
 	trap.o\
 	uart.o\
 	vectors.o\
-        vm.o\
+	vm.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += mmu64.o
@@ -56,22 +56,11 @@ endif
 # If the makefile can't find QEMU, specify its path here
 # QEMU = qemu-system-i386
 
-# Try to infer the correct QEMU
+# Try to infer the correct QEMU if not provided. Leave empty when none found.
 ifndef QEMU
-QEMU = $(shell if which qemu > /dev/null; \
-	then echo qemu; exit; \
-	elif which qemu-system-i386 > /dev/null; \
-	then echo qemu-system-i386; exit; \
-	elif which qemu-system-x86_64 > /dev/null; \
-	then echo qemu-system-x86_64; exit; \
-	else \
-	qemu=/Applications/Q.app/Contents/MacOS/i386-softmmu.app/Contents/MacOS/i386-softmmu; \
-	if test -x $$qemu; then echo $$qemu; exit; fi; fi; \
-	echo "***" 1>&2; \
-	echo "*** Error: Couldn't find a working QEMU executable." 1>&2; \
-	echo "*** Is the directory containing the qemu binary in your PATH" 1>&2; \
-	echo "*** or have you tried setting the QEMU variable in Makefile?" 1>&2; \
-	echo "***" 1>&2; exit 1)
+QEMU := $(shell which qemu-system-i386 2>/dev/null || \
+       which qemu-system-x86_64 2>/dev/null || \
+       which qemu 2>/dev/null)
 endif
 
 ARCH ?= i686
@@ -88,6 +77,7 @@ OBJS += swtch.o
 
 BOOTASM := bootasm.S
 ENTRYASM := entry.S
+endif
 
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
@@ -201,21 +191,21 @@ mkfs: mkfs.c fs.h
 .PRECIOUS: %.o
 
 UPROGS=\
-        _cat\
-        _echo\
-        _forktest\
-        _grep\
-        _init\
-        _kill\
-        _ln\
-        _ls\
-        _mkdir\
-        _rm\
-        _sh\
-        _stressfs\
-        _usertests\
-        _wc\
-        _zombie\
+	_cat\
+	_echo\
+	_forktest\
+	_grep\
+	_init\
+	_kill\
+	_ln\
+	_ls\
+	_mkdir\
+	_rm\
+	_sh\
+	_stressfs\
+	_usertests\
+	_wc\
+	_zombie\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))
@@ -262,24 +252,44 @@ endif
 QEMUOPTS = -drive file=$(FS_IMG),index=1,media=disk,format=raw -drive file=$(XV6_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 512 $(QEMUEXTRA)
 
 qemu: $(FS_IMG) $(XV6_IMG)
-	$(QEMU) -serial mon:stdio $(QEMUOPTS)
+	if [ -z "$(QEMU)" ]; then \
+	        echo "QEMU not found. Kernel built but not executed."; \
+	else \
+	        $(QEMU) -serial mon:stdio $(QEMUOPTS); \
+	fi
 
 qemu-memfs: $(XV6_MEMFS_IMG)
-	$(QEMU) -drive file=$(XV6_MEMFS_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 256
+	if [ -z "$(QEMU)" ]; then \
+	        echo "QEMU not found. Kernel built but not executed."; \
+	else \
+	        $(QEMU) -drive file=$(XV6_MEMFS_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 256; \
+	fi
 
 qemu-nox: $(FS_IMG) $(XV6_IMG)
-	$(QEMU) -nographic $(QEMUOPTS)
+	if [ -z "$(QEMU)" ]; then \
+	        echo "QEMU not found. Kernel built but not executed."; \
+	else \
+	        $(QEMU) -nographic $(QEMUOPTS); \
+	fi
 
 .gdbinit: .gdbinit.tmpl
 	sed "s/localhost:1234/localhost:$(GDBPORT)/" < $^ > $@
 
 qemu-gdb: $(FS_IMG) $(XV6_IMG) .gdbinit
 	@echo "*** Now run 'gdb'." 1>&2
-	$(QEMU) -serial mon:stdio $(QEMUOPTS) -S $(QEMUGDB)
+	if [ -z "$(QEMU)" ]; then \
+	        echo "QEMU not found. GDB stub unavailable."; \
+	else \
+	        $(QEMU) -serial mon:stdio $(QEMUOPTS) -S $(QEMUGDB); \
+	fi
 
 qemu-nox-gdb: $(FS_IMG) $(XV6_IMG) .gdbinit
 	@echo "*** Now run 'gdb'." 1>&2
-	$(QEMU) -nographic $(QEMUOPTS) -S $(QEMUGDB)
+	if [ -z "$(QEMU)" ]; then \
+	        echo "QEMU not found. GDB stub unavailable."; \
+	else \
+	        $(QEMU) -nographic $(QEMUOPTS) -S $(QEMUGDB); \
+	fi
 
 # CUT HERE
 # prepare dist for students

--- a/asm.h
+++ b/asm.h
@@ -1,3 +1,5 @@
+#pragma once
+
 //
 // assembler macros to create x86 segments
 //

--- a/buf.h
+++ b/buf.h
@@ -1,3 +1,5 @@
+#pragma once
+
 struct buf {
   int flags;
   uint dev;

--- a/date.h
+++ b/date.h
@@ -1,3 +1,5 @@
+#pragma once
+
 struct rtcdate {
   uint second;
   uint minute;

--- a/defs.h
+++ b/defs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 struct buf;
 struct context;
 #ifdef __x86_64__

--- a/elf.h
+++ b/elf.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Format of an ELF executable file
 
 #define ELF_MAGIC 0x464C457FU  // "\x7FELF" in little endian

--- a/fcntl.h
+++ b/fcntl.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define O_RDONLY  0x000
 #define O_WRONLY  0x001
 #define O_RDWR    0x002

--- a/file.h
+++ b/file.h
@@ -1,3 +1,5 @@
+#pragma once
+
 struct file {
   enum { FD_NONE, FD_PIPE, FD_INODE } type;
   int ref; // reference count

--- a/fs.h
+++ b/fs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
 

--- a/kbd.h
+++ b/kbd.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // PC keyboard interface constants
 
 #define KBSTATP         0x64    // kbd controller status port(I)

--- a/memlayout.h
+++ b/memlayout.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Memory layout
 
 #define EXTMEM 0x100000 // Start of extended memory

--- a/mmu.h
+++ b/mmu.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // This file contains definitions for the
 // x86 memory management unit (MMU).
 

--- a/mp.h
+++ b/mp.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // See MultiProcessor Specification Version 1.[14]
 
 struct mp {             // floating pointer

--- a/param.h
+++ b/param.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define NPROC        64  // maximum number of processes
 #define KSTACKSIZE 4096  // size of per-process kernel stack
 #define NCPU          8  // maximum number of CPUs

--- a/proc.h
+++ b/proc.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Context used for kernel context switches.
 #ifdef __x86_64__
 struct context64;

--- a/sh.c
+++ b/sh.c
@@ -62,11 +62,6 @@ static void __attribute__((noreturn)) runcmd(struct cmd *cmd);
 
 
 
-
-static void
-
-
-
 static void __attribute__((noreturn))
 runcmd(struct cmd *cmd)
 {

--- a/sleeplock.h
+++ b/sleeplock.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Long-term locks for processes
 struct sleeplock {
   uint locked;       // Is the lock held?

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Mutual exclusion lock.
 struct spinlock {
   uint locked;       // Is the lock held?

--- a/stat.h
+++ b/stat.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define T_DIR  1   // Directory
 #define T_FILE 2   // File
 #define T_DEV  3   // Device

--- a/syscall.h
+++ b/syscall.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // System call numbers
 #define SYS_fork    1
 #define SYS_exit    2

--- a/traps.h
+++ b/traps.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // x86 trap and interrupt constants.
 
 // Processor-defined:

--- a/user.h
+++ b/user.h
@@ -1,3 +1,5 @@
+#pragma once
+
 struct stat;
 struct rtcdate;
 

--- a/x86.h
+++ b/x86.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Routines to let C code use special x86 instructions.
 
 static inline uchar inb(ushort port) {


### PR DESCRIPTION
## Summary
- close open conditional in Makefile
- relax QEMU autodetect so the build works without the emulator
- print helpful messages when running `make qemu*` without qemu
- clean up stray lines in `sh.c`

## Testing
- `make clean`
- `make`
- `make qemu`