### PR TITLE
Add compile-time size checks for structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ OBJS += swtch.o
 
 BOOTASM := bootasm.S
 ENTRYASM := entry.S
+endif
 
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas

--- a/file.h
+++ b/file.h
@@ -24,6 +24,8 @@ struct inode {
   uint size;
   uint addrs[NDIRECT+1];
 };
+// Must match on-disk inode layout; inode is expected to be 144 bytes
+_Static_assert(sizeof(struct inode) == 144, "struct inode size incorrect");
 
 // table mapping major device number to
 // device functions

--- a/mmu.h
+++ b/mmu.h
@@ -38,6 +38,8 @@ struct segdesc {
   uint g : 1;          // Granularity: limit scaled by 4K when set
   uint base_31_24 : 8; // High bits of segment base address
 };
+// Ensure the descriptor is exactly 8 bytes so assembly structures match
+_Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
 
 // Normal segment
 #define SEG(type, base, lim, dpl)                                              \

--- a/proc.h
+++ b/proc.h
@@ -40,6 +40,8 @@ struct context {
   uint ebp;
   uint eip;
 };
+// Check that context saved by swtch.S matches this layout (5 registers)
+_Static_assert(sizeof(struct context) == 20, "struct context size incorrect");
 
 #ifdef __x86_64__
 struct context64 {
@@ -72,6 +74,8 @@ struct proc {
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
 };
+// Ensure scheduler and utilities rely on fixed proc size (124 bytes)
+_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text


### PR DESCRIPTION
## Summary
- ensure `segdesc`, `context`, `inode`, and `proc` match expected sizes
- document expected struct sizes with static assertions
- fix Makefile syntax so `make clean` works

## Testing
- `make clean`
- `make`
