### PR TITLE
Add exo block capability and syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
 # Output file names depend on the target architecture
-KERNEL_FILE := kernel
-KERNELMEMFS_FILE := kernelmemfs
+KERNEL_FILE := kernel.bin
+KERNELMEMFS_FILE := kernelmemfs.bin
 FS_IMG := fs.img
 XV6_IMG := xv6.img
 XV6_MEMFS_IMG := xv6memfs.img
@@ -230,8 +230,8 @@ $(FS_IMG): mkfs README $(UPROGS)
 clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*.o *.d *.asm *.sym vectors.S bootblock entryother entryother64 \
-	initcode initcode.out kernel kernel64 xv6.img xv6-64.img \
-	fs.img fs64.img kernelmemfs kernelmemfs64 xv6memfs.img \
+       initcode initcode.out kernel.bin kernel64 xv6.img xv6-64.img \
+       fs.img fs64.img kernelmemfs.bin kernelmemfs64 xv6memfs.img \
 	xv6memfs-64.img mkfs .gdbinit \
 	$(UPROGS)
 

--- a/defs.h
+++ b/defs.h
@@ -16,6 +16,7 @@ struct sleeplock;
 struct stat;
 struct superblock;
 struct exo_cap;
+struct exo_blockcap;
 
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
@@ -207,6 +208,8 @@ int copyout(pde_t *, uint, void *, uint);
 void            clearpteu(pde_t *pgdir, char *uva);
 struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
+struct exo_blockcap exo_alloc_block(uint dev);
+void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
 
 void clearpteu(pde_t *pgdir, char *uva);
 

--- a/exo.h
+++ b/exo.h
@@ -6,6 +6,11 @@ typedef struct exo_cap {
   uint pa;
 } exo_cap;
 
+typedef struct exo_blockcap {
+  uint dev;
+  uint blockno;
+} exo_blockcap;
+
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
 

--- a/kernel/exo_cpu.h
+++ b/kernel/exo_cpu.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "exo_mem.h"
-#include <stdint.h>
+#include "../exo.h"
 
-int exo_yield_to(cap_t target);
+int exo_yield_to(exo_cap target);

--- a/kernel/exo_disk.h
+++ b/kernel/exo_disk.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "exo_mem.h"
-#include <stdint.h>
+#include "../exo.h"
 
-int exo_read_disk(cap_t cap, void *dst, uint64_t off, uint64_t n);
-int exo_write_disk(cap_t cap, const void *src, uint64_t off, uint64_t n);
+int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n);
+int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n);

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "exo_mem.h"
-#include <stdint.h>
+#include "../exo.h"
 
-int exo_send(cap_t dest, const void *buf, uint64_t len);
-int exo_recv(cap_t src, void *buf, uint64_t len);
+int exo_send(exo_cap dest, const void *buf, uint64_t len);
+int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/kernel/exo_mem.h
+++ b/kernel/exo_mem.h
@@ -1,8 +1,5 @@
 #pragma once
-#include <stdint.h>
+#include "../exo.h"
 
-typedef uint64_t cap_t;
-
-cap_t exo_alloc_page(void);
-int exo_bind_page(cap_t cap, void *va, int perm);
-int exo_unbind_page(void *va);
+exo_cap exo_alloc_page(void);
+int exo_unbind_page(exo_cap cap);

--- a/syscall.c
+++ b/syscall.c
@@ -140,48 +140,38 @@ extern int sys_write(void);
 extern int sys_uptime(void);
 
 extern int sys_set_timer_upcall(void);
-
-static int (*syscalls[])(void) = {
-    [SYS_fork] sys_fork,     [SYS_exit] sys_exit,
-    [SYS_wait] sys_wait,     [SYS_pipe] sys_pipe,
-    [SYS_read] sys_read,     [SYS_kill] sys_kill,
-    [SYS_exec] sys_exec,     [SYS_fstat] sys_fstat,
-    [SYS_chdir] sys_chdir,   [SYS_dup] sys_dup,
-    [SYS_getpid] sys_getpid, [SYS_sbrk] sys_sbrk,
-    [SYS_sleep] sys_sleep,   [SYS_uptime] sys_uptime,
-    [SYS_open] sys_open,     [SYS_write] sys_write,
-    [SYS_mknod] sys_mknod,   [SYS_unlink] sys_unlink,
-    [SYS_link] sys_link,     [SYS_mkdir] sys_mkdir,
-    [SYS_close] sys_close,   [SYS_set_timer_upcall] sys_set_timer_upcall,
-
 extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
+extern int sys_exo_alloc_block(void);
+extern int sys_exo_bind_block(void);
 
 static int (*syscalls[])(void) = {
-[SYS_fork]    sys_fork,
-[SYS_exit]    sys_exit,
-[SYS_wait]    sys_wait,
-[SYS_pipe]    sys_pipe,
-[SYS_read]    sys_read,
-[SYS_kill]    sys_kill,
-[SYS_exec]    sys_exec,
-[SYS_fstat]   sys_fstat,
-[SYS_chdir]   sys_chdir,
-[SYS_dup]     sys_dup,
-[SYS_getpid]  sys_getpid,
-[SYS_sbrk]    sys_sbrk,
-[SYS_sleep]   sys_sleep,
-[SYS_uptime]  sys_uptime,
-[SYS_open]    sys_open,
-[SYS_write]   sys_write,
-[SYS_mknod]   sys_mknod,
-[SYS_unlink]  sys_unlink,
-[SYS_link]    sys_link,
-[SYS_mkdir]   sys_mkdir,
-[SYS_close]   sys_close,
-[SYS_exo_alloc_page] sys_exo_alloc_page,
-[SYS_exo_unbind_page] sys_exo_unbind_page,
-
+    [SYS_fork] sys_fork,
+    [SYS_exit] sys_exit,
+    [SYS_wait] sys_wait,
+    [SYS_pipe] sys_pipe,
+    [SYS_read] sys_read,
+    [SYS_kill] sys_kill,
+    [SYS_exec] sys_exec,
+    [SYS_fstat] sys_fstat,
+    [SYS_chdir] sys_chdir,
+    [SYS_dup] sys_dup,
+    [SYS_getpid] sys_getpid,
+    [SYS_sbrk] sys_sbrk,
+    [SYS_sleep] sys_sleep,
+    [SYS_uptime] sys_uptime,
+    [SYS_open] sys_open,
+    [SYS_write] sys_write,
+    [SYS_mknod] sys_mknod,
+    [SYS_unlink] sys_unlink,
+    [SYS_link] sys_link,
+    [SYS_mkdir] sys_mkdir,
+    [SYS_close] sys_close,
+    [SYS_set_timer_upcall] sys_set_timer_upcall,
+    [SYS_exo_alloc_page] sys_exo_alloc_page,
+    [SYS_exo_unbind_page] sys_exo_unbind_page,
+    [SYS_exo_alloc_block] sys_exo_alloc_block,
+    [SYS_exo_bind_block] sys_exo_bind_block,
 };
 
 void syscall(void) {

--- a/syscall.h
+++ b/syscall.h
@@ -21,5 +21,7 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_set_timer_upcall 22
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
+#define SYS_exo_alloc_page 23
+#define SYS_exo_unbind_page 24
+#define SYS_exo_alloc_block 25
+#define SYS_exo_bind_block 26

--- a/sysproc.c
+++ b/sysproc.c
@@ -1,5 +1,5 @@
-#include "date.h"
 #include "defs.h"
+#include "date.h"
 #include "memlayout.h"
 #include "mmu.h"
 #include "param.h"
@@ -7,6 +7,10 @@
 #include "types.h"
 #include "x86.h"
 #include "exo.h"
+#include "fs.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "buf.h"
 
 
 int sys_fork(void) { return fork(); }
@@ -77,6 +81,7 @@ int sys_set_timer_upcall(void) {
     return -1;
   myproc()->timer_upcall = handler;
   return 0;
+}
 
 // allocate a physical page and return its capability
 int
@@ -94,5 +99,39 @@ sys_exo_unbind_page(void)
   if(argint(0, (int*)&cap.pa) < 0)
     return -1;
   return exo_unbind_page(cap);
+}
 
+int sys_exo_alloc_block(void) {
+  int dev;
+  struct exo_blockcap *ucap;
+  struct exo_blockcap cap;
+  if (argint(0, &dev) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
+    return -1;
+  cap = exo_alloc_block(dev);
+  ucap->dev = cap.dev;
+  ucap->blockno = cap.blockno;
+  return 0;
+}
+
+int sys_exo_bind_block(void) {
+  struct exo_blockcap *ucap, cap;
+  char *data;
+  int write;
+  struct buf b;
+
+  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
+      argptr(1, &data, BSIZE) < 0 || argint(2, &write) < 0)
+    return -1;
+
+  cap = *ucap;
+  memset(&b, 0, sizeof(b));
+  initsleeplock(&b.lock, "exoblk");
+  acquiresleep(&b.lock);
+  if (write)
+    memmove(b.data, data, BSIZE);
+  exo_bind_block(&cap, &b, write);
+  if (!write)
+    memmove(data, b.data, BSIZE);
+  releasesleep(&b.lock);
+  return 0;
 }

--- a/types.h
+++ b/types.h
@@ -2,16 +2,22 @@
 
 typedef unsigned int uint;
 typedef unsigned short ushort;
-typedef unsigned char  uchar;
-typedef unsigned long long uint64;
-typedef uint pde_t;
-
 typedef unsigned char uchar;
 typedef unsigned long long uint64;
+typedef signed long long int64;
+
+typedef unsigned int uint32_t;
+typedef int int32_t;
+typedef unsigned long long uint64_t;
+typedef long long int64_t;
+typedef unsigned short uint16_t;
+typedef short int16_t;
+typedef unsigned char uint8_t;
+typedef signed char int8_t;
 
 typedef unsigned long uintptr_t;
 
-#ifdef __x86_64__i
+#ifdef __x86_64__
 typedef unsigned long long pde_t;
 #else
 typedef unsigned int pde_t;

--- a/user.h
+++ b/user.h
@@ -31,6 +31,8 @@ int uptime(void);
 int set_timer_upcall(void (*handler)(void));
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap);
+int exo_alloc_block(uint dev, exo_blockcap *cap);
+int exo_bind_block(exo_blockcap *cap, void *data, int write);
 
 
 // ulib.c

--- a/usys.S
+++ b/usys.S
@@ -41,4 +41,6 @@ SYSCALL(uptime)
 SYSCALL(set_timer_upcall)
 SYSCALL(exo_alloc_page)
 SYSCALL(exo_unbind_page)
+SYSCALL(exo_alloc_block)
+SYSCALL(exo_bind_block)
 


### PR DESCRIPTION
## Summary
- introduce `exo_blockcap` and related helpers
- clean up header dependencies
- adjust Makefile output names to avoid collision with header directory
- fix syscall table and sysproc implementations

## Testing
- `make -s`