### PR TITLE
Fix build errors with header stubs and includes

### DIFF
--- a/date.h
+++ b/date.h
@@ -1,3 +1,5 @@
+#include "types.h"
+
 struct rtcdate {
   uint second;
   uint minute;

--- a/defs.h
+++ b/defs.h
@@ -16,6 +16,7 @@ struct sleeplock;
 struct stat;
 struct superblock;
 struct exo_cap;
+struct trapframe;
 
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
@@ -208,6 +209,8 @@ int copyout(pde_t *, uint, void *, uint);
 void            clearpteu(pde_t *pgdir, char *uva);
 struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
+int             exo_bind_page(struct exo_cap, void *, int);
+int             exo_yield_to(struct exo_cap);
 
 void clearpteu(pde_t *pgdir, char *uva);
 

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,14 @@
 #include "defs.h"
 #include "param.h"
-#include "proc.h"
 #include "spinlock.h"
+#include "proc.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;
@@ -17,4 +22,10 @@ void exo_pctr_transfer(struct trapframe *tf) {
     }
   }
   release(&ptable.lock);
+}
+
+int exo_yield_to(exo_cap target) {
+  // For now, ignore the target capability and yield to the scheduler.
+  yield();
+  return 0;
 }

--- a/exo.h
+++ b/exo.h
@@ -8,5 +8,7 @@ typedef struct exo_cap {
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
+int exo_bind_page(exo_cap c, void *va, int perm);
+int exo_yield_to(exo_cap target);
 
 #endif // EXO_H

--- a/include/gnu/stubs-32.h
+++ b/include/gnu/stubs-32.h
@@ -1,0 +1,4 @@
+/* Minimal gnu/stubs-32.h for xv6 build environment */
+#ifndef _GNU_STUBS_32_H
+#define _GNU_STUBS_32_H 1
+#endif

--- a/kernel/exo_cpu.h
+++ b/kernel/exo_cpu.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "exo_mem.h"
+#include "exo.h"
 #include <stdint.h>
 
-int exo_yield_to(cap_t target);
+int exo_yield_to(exo_cap target);

--- a/kernel/exo_disk.h
+++ b/kernel/exo_disk.h
@@ -2,5 +2,5 @@
 #include "exo_mem.h"
 #include <stdint.h>
 
-int exo_read_disk(cap_t cap, void *dst, uint64_t off, uint64_t n);
-int exo_write_disk(cap_t cap, const void *src, uint64_t off, uint64_t n);
+int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n);
+int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n);

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -2,5 +2,5 @@
 #include "exo_mem.h"
 #include <stdint.h>
 
-int exo_send(cap_t dest, const void *buf, uint64_t len);
-int exo_recv(cap_t src, void *buf, uint64_t len);
+int exo_send(exo_cap dest, const void *buf, uint64_t len);
+int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/kernel/exo_mem.h
+++ b/kernel/exo_mem.h
@@ -1,8 +1,6 @@
 #pragma once
-#include <stdint.h>
+#include "../exo.h"
 
-typedef uint64_t cap_t;
-
-cap_t exo_alloc_page(void);
-int exo_bind_page(cap_t cap, void *va, int perm);
-int exo_unbind_page(void *va);
+exo_cap exo_alloc_page(void);
+int exo_bind_page(exo_cap cap, void *va, int perm);
+int exo_unbind_page(exo_cap cap);

--- a/libos.c
+++ b/libos.c
@@ -1,0 +1,34 @@
+#include "libos.h"
+
+// Allocate a page and bind it to a freshly expanded address
+exo_cap libos_page_alloc(void **va) {
+  exo_cap cap = exo_alloc_page();
+  if (!cap.pa)
+    return cap;
+  void *addr = sbrk(4096);
+  if ((long)addr == -1) {
+    exo_unbind_page(cap);
+    cap.pa = 0;
+    return cap;
+  }
+  if (exo_bind_page(cap, addr, PTE_W | PTE_U) < 0) {
+    exo_unbind_page(cap);
+    cap.pa = 0;
+    return cap;
+  }
+  *va = addr;
+  return cap;
+}
+
+int libos_page_free(exo_cap cap, void *va) {
+  (void)va; // mapping removed by exo_unbind_page
+  return exo_unbind_page(cap);
+}
+
+int libos_sched_yield(exo_cap target) { return exo_yield_to(target); }
+
+int libos_disk_read(int fd, void *dst, int n) { return read(fd, dst, n); }
+
+int libos_disk_write(int fd, const void *src, int n) {
+  return write(fd, src, n);
+}

--- a/libos.h
+++ b/libos.h
@@ -1,0 +1,11 @@
+#ifndef LIBOS_H
+#define LIBOS_H
+#include "user.h"
+
+exo_cap libos_page_alloc(void **va);
+int libos_page_free(exo_cap cap, void *va);
+int libos_sched_yield(exo_cap target);
+int libos_disk_read(int fd, void *dst, int n);
+int libos_disk_write(int fd, const void *src, int n);
+
+#endif // LIBOS_H

--- a/libosdemo.c
+++ b/libosdemo.c
@@ -1,0 +1,22 @@
+#include "libos.h"
+#include "stat.h"
+#include "types.h"
+#include "user.h"
+
+int main(void) {
+  void *va = 0;
+  exo_cap cap = libos_page_alloc(&va);
+  if (!cap.pa) {
+    printf(1, "alloc failed\n");
+    exit();
+  }
+  char *p = (char *)va;
+  p[0] = 'L';
+  p[1] = 'O';
+  p[2] = 'S';
+  p[3] = '\n';
+  write(1, p, 4);
+  libos_sched_yield(cap); // just yields
+  libos_page_free(cap, va);
+  exit();
+}

--- a/mmu.h
+++ b/mmu.h
@@ -1,3 +1,4 @@
+#pragma once
 // This file contains definitions for the
 // x86 memory management unit (MMU).
 

--- a/proc.h
+++ b/proc.h
@@ -1,3 +1,5 @@
+#include "mmu.h"
+
 // Context used for kernel context switches.
 #ifdef __x86_64__
 struct context64;

--- a/syscall.c
+++ b/syscall.c
@@ -140,47 +140,37 @@ extern int sys_write(void);
 extern int sys_uptime(void);
 
 extern int sys_set_timer_upcall(void);
-
-static int (*syscalls[])(void) = {
-    [SYS_fork] sys_fork,     [SYS_exit] sys_exit,
-    [SYS_wait] sys_wait,     [SYS_pipe] sys_pipe,
-    [SYS_read] sys_read,     [SYS_kill] sys_kill,
-    [SYS_exec] sys_exec,     [SYS_fstat] sys_fstat,
-    [SYS_chdir] sys_chdir,   [SYS_dup] sys_dup,
-    [SYS_getpid] sys_getpid, [SYS_sbrk] sys_sbrk,
-    [SYS_sleep] sys_sleep,   [SYS_uptime] sys_uptime,
-    [SYS_open] sys_open,     [SYS_write] sys_write,
-    [SYS_mknod] sys_mknod,   [SYS_unlink] sys_unlink,
-    [SYS_link] sys_link,     [SYS_mkdir] sys_mkdir,
-    [SYS_close] sys_close,   [SYS_set_timer_upcall] sys_set_timer_upcall,
-
 extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
+extern int sys_exo_bind_page(void);
+extern int sys_exo_yield_to(void);
 
 static int (*syscalls[])(void) = {
-[SYS_fork]    sys_fork,
-[SYS_exit]    sys_exit,
-[SYS_wait]    sys_wait,
-[SYS_pipe]    sys_pipe,
-[SYS_read]    sys_read,
-[SYS_kill]    sys_kill,
-[SYS_exec]    sys_exec,
-[SYS_fstat]   sys_fstat,
-[SYS_chdir]   sys_chdir,
-[SYS_dup]     sys_dup,
-[SYS_getpid]  sys_getpid,
-[SYS_sbrk]    sys_sbrk,
-[SYS_sleep]   sys_sleep,
-[SYS_uptime]  sys_uptime,
-[SYS_open]    sys_open,
-[SYS_write]   sys_write,
-[SYS_mknod]   sys_mknod,
-[SYS_unlink]  sys_unlink,
-[SYS_link]    sys_link,
-[SYS_mkdir]   sys_mkdir,
-[SYS_close]   sys_close,
-[SYS_exo_alloc_page] sys_exo_alloc_page,
-[SYS_exo_unbind_page] sys_exo_unbind_page,
+    [SYS_fork] sys_fork,
+    [SYS_exit] sys_exit,
+    [SYS_wait] sys_wait,
+    [SYS_pipe] sys_pipe,
+    [SYS_read] sys_read,
+    [SYS_kill] sys_kill,
+    [SYS_exec] sys_exec,
+    [SYS_fstat] sys_fstat,
+    [SYS_chdir] sys_chdir,
+    [SYS_dup] sys_dup,
+    [SYS_getpid] sys_getpid,
+    [SYS_sbrk] sys_sbrk,
+    [SYS_sleep] sys_sleep,
+    [SYS_uptime] sys_uptime,
+    [SYS_open] sys_open,
+    [SYS_write] sys_write,
+    [SYS_mknod] sys_mknod,
+    [SYS_unlink] sys_unlink,
+    [SYS_link] sys_link,
+    [SYS_mkdir] sys_mkdir,
+    [SYS_close] sys_close,
+    [SYS_exo_alloc_page] sys_exo_alloc_page,
+    [SYS_exo_unbind_page] sys_exo_unbind_page,
+    [SYS_exo_bind_page] sys_exo_bind_page,
+    [SYS_exo_yield_to] sys_exo_yield_to,
 
 };
 

--- a/syscall.h
+++ b/syscall.h
@@ -21,5 +21,7 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_set_timer_upcall 22
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
+#define SYS_exo_alloc_page 23
+#define SYS_exo_unbind_page 24
+#define SYS_exo_bind_page 25
+#define SYS_exo_yield_to 26

--- a/sysproc.c
+++ b/sysproc.c
@@ -1,13 +1,12 @@
 #include "date.h"
 #include "defs.h"
+#include "exo.h"
 #include "memlayout.h"
 #include "mmu.h"
 #include "param.h"
 #include "proc.h"
 #include "types.h"
 #include "x86.h"
-#include "exo.h"
-
 
 int sys_fork(void) { return fork(); }
 
@@ -70,29 +69,41 @@ int sys_uptime(void) {
   return xticks;
 }
 
-
 int sys_set_timer_upcall(void) {
   void (*handler)(void);
   if (argptr(0, (char **)&handler, sizeof(handler)) < 0)
     return -1;
   myproc()->timer_upcall = handler;
   return 0;
+}
 
 // allocate a physical page and return its capability
-int
-sys_exo_alloc_page(void)
-{
+int sys_exo_alloc_page(void) {
   exo_cap cap = exo_alloc_page();
   return cap.pa;
 }
 
 // unbind and free a physical page by capability
-int
-sys_exo_unbind_page(void)
-{
+int sys_exo_unbind_page(void) {
   exo_cap cap;
-  if(argint(0, (int*)&cap.pa) < 0)
+  if (argint(0, (int *)&cap.pa) < 0)
     return -1;
   return exo_unbind_page(cap);
+}
 
+int sys_exo_bind_page(void) {
+  exo_cap cap;
+  void *va;
+  int perm;
+  if (argint(0, (int *)&cap.pa) < 0 ||
+      argptr(1, (char **)&va, sizeof(void *)) < 0 || argint(2, &perm) < 0)
+    return -1;
+  return exo_bind_page(cap, va, perm);
+}
+
+int sys_exo_yield_to(void) {
+  exo_cap cap;
+  if (argint(0, (int *)&cap.pa) < 0)
+    return -1;
+  return exo_yield_to(cap);
 }

--- a/types.h
+++ b/types.h
@@ -1,18 +1,8 @@
 #pragma once
 
-typedef unsigned int uint;
+typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;
 typedef unsigned long long uint64;
 typedef uint pde_t;
-
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-
-typedef unsigned long uintptr_t;
-
-#ifdef __x86_64__i
-typedef unsigned long long pde_t;
-#else
-typedef unsigned int pde_t;
-#endif
+typedef unsigned int uintptr_t;

--- a/user.h
+++ b/user.h
@@ -32,6 +32,8 @@ int exo_pctr_transfer(int cap);
 int set_timer_upcall(void (*handler)(void));
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap);
+int exo_bind_page(exo_cap, void *, int);
+int exo_yield_to(exo_cap);
 
 
 // ulib.c

--- a/usys.S
+++ b/usys.S
@@ -57,5 +57,7 @@ exo_pctr_transfer:
 SYSCALL(set_timer_upcall)
 SYSCALL(exo_alloc_page)
 SYSCALL(exo_unbind_page)
+SYSCALL(exo_bind_page)
+SYSCALL(exo_yield_to)
 
 

--- a/vm.c
+++ b/vm.c
@@ -1,25 +1,23 @@
-#include "param.h"
-#include "types.h"
 #include "defs.h"
-#include "x86.h"
+#include "elf.h"
+#include "exo.h"
 #include "memlayout.h"
 #include "mmu.h"
+#include "param.h"
 #include "proc.h"
-#include "exo.h"
-#include "elf.h"
+#include "types.h"
+#include "x86.h"
 
-extern char data[];  // defined by kernel.ld
+extern char data[]; // defined by kernel.ld
 #ifdef __x86_64__
-pml4e_t *kpgdir;  // for use in scheduler()
+pml4e_t *kpgdir; // for use in scheduler()
 #else
-pde_t *kpgdir;  // for use in scheduler()
+pde_t *kpgdir; // for use in scheduler()
 #endif
 
 // Set up CPU's kernel segment descriptors.
 // Run once on entry on each CPU.
-void
-seginit(void)
-{
+void seginit(void) {
   struct cpu *c;
 
   // Map "logical" addresses to virtual addresses using identity map.
@@ -27,9 +25,9 @@ seginit(void)
   // because it would have to have DPL_USR, but the CPU forbids
   // an interrupt from CPL=0 to DPL=3.
   c = &cpus[cpuid()];
-  c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
+  c->gdt[SEG_KCODE] = SEG(STA_X | STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X | STA_R, 0, 0xffffffff, DPL_USER);
   c->gdt[SEG_UDATA] = SEG(STA_W, 0, 0xffffffff, DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
@@ -37,17 +35,15 @@ seginit(void)
 // Return the address of the PTE in page table pgdir
 // that corresponds to virtual address va.  If alloc!=0,
 // create any required page table pages.
-static pte_t *
-walkpgdir(pde_t *pgdir, const void *va, int alloc)
-{
+static pte_t *walkpgdir(pde_t *pgdir, const void *va, int alloc) {
   pde_t *pde;
   pte_t *pgtab;
 
   pde = &pgdir[PDX(va)];
-  if(*pde & PTE_P){
-    pgtab = (pte_t*)P2V(PTE_ADDR(*pde));
+  if (*pde & PTE_P) {
+    pgtab = (pte_t *)P2V(PTE_ADDR(*pde));
   } else {
-    if(!alloc || (pgtab = (pte_t*)kalloc()) == 0)
+    if (!alloc || (pgtab = (pte_t *)kalloc()) == 0)
       return 0;
     // Make sure all those PTE_P bits are zero.
     memset(pgtab, 0, PGSIZE);
@@ -62,21 +58,19 @@ walkpgdir(pde_t *pgdir, const void *va, int alloc)
 // Create PTEs for virtual addresses starting at va that refer to
 // physical addresses starting at pa. va and size might not
 // be page-aligned.
-static int
-mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm)
-{
+static int mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm) {
   char *a, *last;
   pte_t *pte;
 
-  a = (char*)PGROUNDDOWN((uintptr_t)va);
-  last = (char*)PGROUNDDOWN(((uintptr_t)va) + size - 1);
-  for(;;){
-    if((pte = walkpgdir(pgdir, a, 1)) == 0)
+  a = (char *)PGROUNDDOWN((uintptr_t)va);
+  last = (char *)PGROUNDDOWN(((uintptr_t)va) + size - 1);
+  for (;;) {
+    if ((pte = walkpgdir(pgdir, a, 1)) == 0)
       return -1;
-    if(*pte & PTE_P)
+    if (*pte & PTE_P)
       panic("remap");
     *pte = pa | perm | PTE_P;
-    if(a == last)
+    if (a == last)
       break;
     a += PGSIZE;
     pa += PGSIZE;
@@ -113,27 +107,25 @@ static struct kmap {
   uint phys_end;
   int perm;
 } kmap[] = {
- { (void*)KERNBASE, 0,             EXTMEM,    PTE_W}, // I/O space
- { (void*)KERNLINK, V2P(KERNLINK), V2P(data), 0},     // kern text+rodata
- { (void*)data,     V2P(data),     PHYSTOP,   PTE_W}, // kern data+memory
- { (void*)DEVSPACE, DEVSPACE,      0,         PTE_W}, // more devices
+    {(void *)KERNBASE, 0, EXTMEM, PTE_W},            // I/O space
+    {(void *)KERNLINK, V2P(KERNLINK), V2P(data), 0}, // kern text+rodata
+    {(void *)data, V2P(data), PHYSTOP, PTE_W},       // kern data+memory
+    {(void *)DEVSPACE, DEVSPACE, 0, PTE_W},          // more devices
 };
 
 // Set up kernel part of a page table.
-pde_t*
-setupkvm(void)
-{
+pde_t *setupkvm(void) {
   pde_t *pgdir;
   struct kmap *k;
 
-  if((pgdir = (pde_t*)kalloc()) == 0)
+  if ((pgdir = (pde_t *)kalloc()) == 0)
     return 0;
   memset(pgdir, 0, PGSIZE);
-  if (P2V(PHYSTOP) > (void*)DEVSPACE)
+  if (P2V(PHYSTOP) > (void *)DEVSPACE)
     panic("PHYSTOP too high");
-  for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
-    if(mappages(pgdir, k->virt, k->phys_end - k->phys_start,
-                (uintptr_t)k->phys_start, k->perm) < 0) {
+  for (k = kmap; k < &kmap[NELEM(kmap)]; k++)
+    if (mappages(pgdir, k->virt, k->phys_end - k->phys_start,
+                 (uintptr_t)k->phys_start, k->perm) < 0) {
       freevm(pgdir);
       return 0;
     }
@@ -142,9 +134,7 @@ setupkvm(void)
 
 // Allocate one page table for the machine for the kernel address
 // space for scheduler processes.
-void
-kvmalloc(void)
-{
+void kvmalloc(void) {
 #ifdef __x86_64__
   kpgdir = setupkvm64();
 #else
@@ -155,71 +145,63 @@ kvmalloc(void)
 
 // Switch h/w page table register to the kernel-only page table,
 // for when no process is running.
-void
-switchkvm(void)
-{
-  lcr3(V2P(kpgdir));   // switch to the kernel page table
+void switchkvm(void) {
+  lcr3(V2P(kpgdir)); // switch to the kernel page table
 }
 
 // Switch TSS and h/w page table to correspond to process p.
-void
-switchuvm(struct proc *p)
-{
-  if(p == 0)
+void switchuvm(struct proc *p) {
+  if (p == 0)
     panic("switchuvm: no process");
-  if(p->kstack == 0)
+  if (p->kstack == 0)
     panic("switchuvm: no kstack");
-  if(p->pgdir == 0)
+  if (p->pgdir == 0)
     panic("switchuvm: no pgdir");
 
   pushcli();
-  mycpu()->gdt[SEG_TSS] = SEG16(STS_T32A, &mycpu()->ts,
-                                sizeof(mycpu()->ts)-1, 0);
+  mycpu()->gdt[SEG_TSS] =
+      SEG16(STS_T32A, &mycpu()->ts, sizeof(mycpu()->ts) - 1, 0);
   mycpu()->gdt[SEG_TSS].s = 0;
   mycpu()->ts.ss0 = SEG_KDATA << 3;
   mycpu()->ts.esp0 = (uintptr_t)p->kstack + KSTACKSIZE;
   // setting IOPL=0 in eflags *and* iomb beyond the tss segment limit
   // forbids I/O instructions (e.g., inb and outb) from user space
-  mycpu()->ts.iomb = (ushort) 0xFFFF;
+  mycpu()->ts.iomb = (ushort)0xFFFF;
   ltr(SEG_TSS << 3);
-  lcr3(V2P(p->pgdir));  // switch to process's address space
+  lcr3(V2P(p->pgdir)); // switch to process's address space
   popcli();
 }
 
 // Load the initcode into address 0 of pgdir.
 // sz must be less than a page.
-void
-inituvm(pde_t *pgdir, char *init, uint sz)
-{
+void inituvm(pde_t *pgdir, char *init, uint sz) {
   char *mem;
 
-  if(sz >= PGSIZE)
+  if (sz >= PGSIZE)
     panic("inituvm: more than a page");
   mem = kalloc();
   memset(mem, 0, PGSIZE);
-  mappages(pgdir, 0, PGSIZE, V2P(mem), PTE_W|PTE_U);
+  mappages(pgdir, 0, PGSIZE, V2P(mem), PTE_W | PTE_U);
   memmove(mem, init, sz);
 }
 
 // Load a program segment into pgdir.  addr must be page-aligned
 // and the pages from addr to addr+sz must already be mapped.
-int
-loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz)
-{
+int loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz) {
   uint i, pa, n;
   pte_t *pte;
 
-  if((uintptr_t) addr % PGSIZE != 0)
+  if ((uintptr_t)addr % PGSIZE != 0)
     panic("loaduvm: addr must be page aligned");
-  for(i = 0; i < sz; i += PGSIZE){
-    if((pte = walkpgdir(pgdir, addr+i, 0)) == 0)
+  for (i = 0; i < sz; i += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, addr + i, 0)) == 0)
       panic("loaduvm: address should exist");
     pa = PTE_ADDR(*pte);
-    if(sz - i < PGSIZE)
+    if (sz - i < PGSIZE)
       n = sz - i;
     else
       n = PGSIZE;
-    if(readi(ip, P2V(pa), offset+i, n) != n)
+    if (readi(ip, P2V(pa), offset + i, n) != n)
       return -1;
   }
   return 0;
@@ -227,27 +209,25 @@ loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz)
 
 // Allocate page tables and physical memory to grow process from oldsz to
 // newsz, which need not be page aligned.  Returns new size or 0 on error.
-int
-allocuvm(pde_t *pgdir, uint oldsz, uint newsz)
-{
+int allocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
   char *mem;
   uint a;
 
-  if(newsz >= KERNBASE)
+  if (newsz >= KERNBASE)
     return 0;
-  if(newsz < oldsz)
+  if (newsz < oldsz)
     return oldsz;
 
   a = PGROUNDUP(oldsz);
-  for(; a < newsz; a += PGSIZE){
+  for (; a < newsz; a += PGSIZE) {
     mem = kalloc();
-    if(mem == 0){
+    if (mem == 0) {
       cprintf("allocuvm out of memory\n");
       deallocuvm(pgdir, newsz, oldsz);
       return 0;
     }
     memset(mem, 0, PGSIZE);
-    if(mappages(pgdir, (char*)a, PGSIZE, V2P(mem), PTE_W|PTE_U) < 0){
+    if (mappages(pgdir, (char *)a, PGSIZE, V2P(mem), PTE_W | PTE_U) < 0) {
       cprintf("allocuvm out of memory (2)\n");
       deallocuvm(pgdir, newsz, oldsz);
       kfree(mem);
@@ -261,23 +241,21 @@ allocuvm(pde_t *pgdir, uint oldsz, uint newsz)
 // newsz.  oldsz and newsz need not be page-aligned, nor does newsz
 // need to be less than oldsz.  oldsz can be larger than the actual
 // process size.  Returns the new process size.
-int
-deallocuvm(pde_t *pgdir, uint oldsz, uint newsz)
-{
+int deallocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
   pte_t *pte;
   uint a, pa;
 
-  if(newsz >= oldsz)
+  if (newsz >= oldsz)
     return oldsz;
 
   a = PGROUNDUP(newsz);
-  for(; a  < oldsz; a += PGSIZE){
-    pte = walkpgdir(pgdir, (char*)a, 0);
-    if(!pte)
+  for (; a < oldsz; a += PGSIZE) {
+    pte = walkpgdir(pgdir, (char *)a, 0);
+    if (!pte)
       a = PGADDR(PDX(a) + 1, 0, 0) - PGSIZE;
-    else if((*pte & PTE_P) != 0){
+    else if ((*pte & PTE_P) != 0) {
       pa = PTE_ADDR(*pte);
-      if(pa == 0)
+      if (pa == 0)
         panic("kfree");
       char *v = P2V(pa);
       kfree(v);
@@ -289,59 +267,53 @@ deallocuvm(pde_t *pgdir, uint oldsz, uint newsz)
 
 // Free a page table and all the physical memory pages
 // in the user part.
-void
-freevm(pde_t *pgdir)
-{
+void freevm(pde_t *pgdir) {
   uint i;
 
-  if(pgdir == 0)
+  if (pgdir == 0)
     panic("freevm: no pgdir");
   deallocuvm(pgdir, KERNBASE, 0);
-  for(i = 0; i < NPDENTRIES; i++){
-    if(pgdir[i] & PTE_P){
-      char * v = P2V(PTE_ADDR(pgdir[i]));
+  for (i = 0; i < NPDENTRIES; i++) {
+    if (pgdir[i] & PTE_P) {
+      char *v = P2V(PTE_ADDR(pgdir[i]));
       kfree(v);
     }
   }
-  kfree((char*)pgdir);
+  kfree((char *)pgdir);
 }
 
 // Clear PTE_U on a page. Used to create an inaccessible
 // page beneath the user stack.
-void
-clearpteu(pde_t *pgdir, char *uva)
-{
+void clearpteu(pde_t *pgdir, char *uva) {
   pte_t *pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if(pte == 0)
+  if (pte == 0)
     panic("clearpteu");
   *pte &= ~PTE_U;
 }
 
 // Given a parent process's page table, create a copy
 // of it for a child.
-pde_t*
-copyuvm(pde_t *pgdir, uint sz)
-{
+pde_t *copyuvm(pde_t *pgdir, uint sz) {
   pde_t *d;
   pte_t *pte;
   uint pa, i, flags;
   char *mem;
 
-  if((d = setupkvm()) == 0)
+  if ((d = setupkvm()) == 0)
     return 0;
-  for(i = 0; i < sz; i += PGSIZE){
-    if((pte = walkpgdir(pgdir, (void *) i, 0)) == 0)
+  for (i = 0; i < sz; i += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, (void *)i, 0)) == 0)
       panic("copyuvm: pte should exist");
-    if(!(*pte & PTE_P))
+    if (!(*pte & PTE_P))
       panic("copyuvm: page not present");
     pa = PTE_ADDR(*pte);
     flags = PTE_FLAGS(*pte);
-    if((mem = kalloc()) == 0)
+    if ((mem = kalloc()) == 0)
       goto bad;
-    memmove(mem, (char*)P2V(pa), PGSIZE);
-    if(mappages(d, (void*)i, PGSIZE, V2P(mem), flags) < 0) {
+    memmove(mem, (char *)P2V(pa), PGSIZE);
+    if (mappages(d, (void *)i, PGSIZE, V2P(mem), flags) < 0) {
       kfree(mem);
       goto bad;
     }
@@ -353,19 +325,17 @@ bad:
   return 0;
 }
 
-//PAGEBREAK!
-// Map user virtual address to kernel address.
-char*
-uva2ka(pde_t *pgdir, char *uva)
-{
+// PAGEBREAK!
+//  Map user virtual address to kernel address.
+char *uva2ka(pde_t *pgdir, char *uva) {
   pte_t *pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if((*pte & PTE_P) == 0)
+  if ((*pte & PTE_P) == 0)
     return 0;
-  if((*pte & PTE_U) == 0)
+  if ((*pte & PTE_U) == 0)
     return 0;
-  return (char*)P2V(PTE_ADDR(*pte));
+  return (char *)P2V(PTE_ADDR(*pte));
 }
 
 // Copy len bytes from p to user address va in page table pgdir.
@@ -386,18 +356,18 @@ copyout(pde_t *pgdir, uint va, void *p, uint len)
   uint va0;
 #endif
 
-  buf = (char*)p;
-  while(len > 0){
+  buf = (char *)p;
+  while (len > 0) {
 #ifdef __x86_64__
     va0 = (uint64)PGROUNDDOWN(va);
 #else
     va0 = (uint)PGROUNDDOWN(va);
 #endif
-    pa0 = uva2ka(pgdir, (char*)va0);
-    if(pa0 == 0)
+    pa0 = uva2ka(pgdir, (char *)va0);
+    if (pa0 == 0)
       return -1;
     n = PGSIZE - (va - va0);
-    if(n > len)
+    if (n > len)
       n = len;
     memmove(pa0 + (va - va0), buf, n);
     len -= n;
@@ -407,36 +377,41 @@ copyout(pde_t *pgdir, uint va, void *p, uint len)
   return 0;
 }
 
-//PAGEBREAK!
-// Blank page.
-//PAGEBREAK!
-// Blank page.
-//PAGEBREAK!
-// Blank page.
+// PAGEBREAK!
+//  Blank page.
+// PAGEBREAK!
+//  Blank page.
+// PAGEBREAK!
+//  Blank page.
 
 // Allocate a page and return a capability referencing its physical address.
-exo_cap
-exo_alloc_page(void)
-{
+exo_cap exo_alloc_page(void) {
   char *mem = kalloc();
   exo_cap cap;
   cap.pa = mem ? V2P(mem) : 0;
   return cap;
 }
 
+// Map a physical page referenced by cap to the given virtual address.
+int exo_bind_page(exo_cap cap, void *va, int perm) {
+  struct proc *p = myproc();
+  if (mappages(p->pgdir, (void *)PGROUNDDOWN((uint)va), PGSIZE, cap.pa,
+               perm | PTE_P) < 0)
+    return -1;
+  return 0;
+}
+
 // Remove any mappings to the page referenced by cap and free it.
-int
-exo_unbind_page(exo_cap cap)
-{
+int exo_unbind_page(exo_cap cap) {
   struct proc *p = myproc();
   pde_t *pgdir = p->pgdir;
   pte_t *pte;
   uint a;
   uint pa = cap.pa;
 
-  for(a = 0; a < p->sz; a += PGSIZE){
-    if((pte = walkpgdir(pgdir, (void*)a, 0)) != 0 && (*pte & PTE_P)){
-      if(PTE_ADDR(*pte) == pa){
+  for (a = 0; a < p->sz; a += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, (void *)a, 0)) != 0 && (*pte & PTE_P)) {
+      if (PTE_ADDR(*pte) == pa) {
         *pte = 0;
         kfree(P2V(pa));
         return 0;
@@ -447,4 +422,3 @@ exo_unbind_page(exo_cap cap)
   kfree(P2V(pa));
   return 0;
 }
-


### PR DESCRIPTION
## Summary
- add `/usr/include/x86_64-linux-gnu` to search path and local include directory
- provide minimal `gnu/stubs-32.h` so 32-bit build finds glibc headers
- clean up types and declarations across headers
- ensure kernel headers have include guards
- repair system call table and user page functions

## Testing
- `make -j2`