### PR TITLE
Fix syscall numbering

### DIFF
--- a/syscall.h
+++ b/syscall.h
@@ -23,11 +23,9 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_mappte 22
-#define SYS_set_timer_upcall 22
-#define SYS_exo_alloc_page 23
-#define SYS_exo_unbind_page 24
-#define SYS_exo_alloc_block 25
-#define SYS_exo_bind_block 26
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
+#define SYS_set_timer_upcall 23
+#define SYS_exo_alloc_page 24
+#define SYS_exo_unbind_page 25
+#define SYS_exo_alloc_block 26
+#define SYS_exo_bind_block 27
 


### PR DESCRIPTION
## Summary
- remove duplicate definitions for `SYS_exo_*`
- make syscall numbers unique and sequential

## Testing
- `make -s` *(fails: `Makefile:116: *** extraneous 'endif'.  Stop.`)*