### PR TITLE
Fix Makefile conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
-endif
-
-endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000


### PR DESCRIPTION
## Summary
- remove leftover `endif` lines in Makefile

## Testing
- `gmake -n _cat`
