### PR TITLE
Fix missing brace in sys_mappte

### DIFF
--- a/sysproc.c
+++ b/sysproc.c
@@ -82,7 +82,7 @@ sys_mappte(void)
   if (argint(0, &va) < 0 || argint(1, &pa) < 0 || argint(2, &perm) < 0)
     return -1;
   return insert_pte(myproc()->pgdir, (void *)va, pa, perm);
-
+}
 
 int sys_set_timer_upcall(void) {
   void (*handler)(void);


### PR DESCRIPTION
## Summary
- close `sys_mappte` with a missing brace

## Testing
- `git log -1 -p`