### PR TITLE
Fix Makefile parse error and header guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
-endif
-
-endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000

--- a/exo_cpu.h
+++ b/exo_cpu.h
@@ -37,5 +37,3 @@ void swtch(context_t **old, context_t *new);
 static inline void cap_yield(context_t **old, context_t *target) {
   swtch(old, target);
 }
-
-#endif // EXO_CPU_H

--- a/types.h
+++ b/types.h
@@ -1,36 +1,14 @@
 #pragma once
 
-#include <stdint.h>
-
-typedef uint8_t  uchar;
-typedef uint16_t ushort;
-typedef uint32_t uint;
-typedef uint64_t uint64;
-
-#ifdef __x86_64__
-typedef uint64_t pde_t;
-typedef uint64_t uintptr_t;
 typedef unsigned int uint;
 typedef unsigned short ushort;
 typedef unsigned char uchar;
 typedef unsigned long long uint64;
-typedef signed long long int64;
-
-typedef unsigned int uint32_t;
-typedef int int32_t;
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-
 typedef unsigned long uintptr_t;
 typedef unsigned int size_t;
 
 #ifdef __x86_64__
 typedef unsigned long long pde_t;
 #else
-typedef uint32_t pde_t;
-typedef uint32_t uintptr_t;
+typedef unsigned int pde_t;
 #endif


### PR DESCRIPTION
## Summary
- remove stray `endif` lines in `Makefile`
- drop leftover header guard from `exo_cpu.h`
- restore simple `types.h` to close unterminated `#ifdef`

## Testing
- `gmake clean`
- `gmake _forktest`