### PR TITLE
Add math_core sizing and demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,7 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
-endif
 
-endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000
@@ -172,7 +170,7 @@ tags: $(OBJS) $(ENTRYOTHERASM) _init
 vectors.S: vectors.pl
 	./vectors.pl > vectors.S
 
-ULIB = ulib.o usys.o printf.o umalloc.o swtch.o
+ULIB = ulib.o usys.o printf.o umalloc.o swtch.o math_core.o
 
 _%: %.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
@@ -206,10 +204,11 @@ UPROGS=\
 	_mkdir\
 	_rm\
 	_sh\
-	_stressfs\
-	_usertests\
-	_wc\
-	_zombie\
+        _stressfs\
+        _usertests\
+        _wc\
+        _zombie\
+        _phi\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/defs.h
+++ b/defs.h
@@ -1,8 +1,4 @@
-
-#pragma once
-
 #include "types.h"
-
 
 struct buf;
 struct context;
@@ -12,6 +8,7 @@ typedef struct context64 context_t;
 #else
 typedef struct context context_t;
 #endif
+struct trapframe;
 struct file;
 struct inode;
 struct pipe;
@@ -21,35 +18,23 @@ struct spinlock;
 struct sleeplock;
 struct stat;
 struct superblock;
-struct exo_cap;
-struct exo_blockcap;
-
-#include "kernel/exo_cpu.h"
-#include "kernel/exo_disk.h"
-#include "kernel/exo_ipc.h"
-#include "kernel/exo_mem.h"
 
 // bio.c
-void binit(void);
-struct buf *bread(uint, uint);
-void brelse(struct buf *);
-void bwrite(struct buf *);
+void            binit(void);
+struct buf*     bread(uint, uint);
+void            brelse(struct buf*);
+void            bwrite(struct buf*);
 
 // console.c
 void            consoleinit(void);
 void            cprintf(char*, ...);
 void            consoleintr(int(*)(void));
-[[noreturn]] void panic(char*);
-void consoleinit(void);
-void cprintf(char *, ...);
-void consoleintr(int (*)(void));
-void panic(char *) __attribute__((noreturn));
+void            panic(char*) __attribute__((noreturn));
 
 // exec.c
-int exec(char *, char **);
+int             exec(char*, char**);
 
 // file.c
-
 struct file*    filealloc(void);
 void            fileclose(struct file*);
 struct file*    filedup(struct file*);
@@ -76,78 +61,50 @@ struct inode*   nameiparent(char*, char*);
 int             readi(struct inode*, char*, uint, size_t);
 void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, char*, uint, size_t);
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
-void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
-
-// fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
-void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
-
 
 // ide.c
-void ideinit(void);
-void ideintr(void);
-void iderw(struct buf *);
+void            ideinit(void);
+void            ideintr(void);
+void            iderw(struct buf*);
 
 // ioapic.c
-void ioapicenable(int irq, int cpu);
-extern uchar ioapicid;
-void ioapicinit(void);
+void            ioapicenable(int irq, int cpu);
+extern uchar    ioapicid;
+void            ioapicinit(void);
 
 // kalloc.c
-char *kalloc(void);
-void kfree(char *);
-void kinit1(void *, void *);
-void kinit2(void *, void *);
+char*           kalloc(void);
+void            kfree(char*);
+void            kinit1(void*, void*);
+void            kinit2(void*, void*);
 
 // kbd.c
-void kbdintr(void);
+void            kbdintr(void);
 
 // lapic.c
-void cmostime(struct rtcdate *r);
-int lapicid(void);
-extern volatile uint *lapic;
-void lapiceoi(void);
-void lapicinit(void);
-void lapicstartap(uchar, uint);
-void microdelay(int);
+void            cmostime(struct rtcdate *r);
+int             lapicid(void);
+extern volatile uint*    lapic;
+void            lapiceoi(void);
+void            lapicinit(void);
+void            lapicstartap(uchar, uint);
+void            microdelay(int);
 
 // log.c
-void initlog(int dev);
-void log_write(struct buf *);
-void begin_op();
-void end_op();
+void            initlog(int dev);
+void            log_write(struct buf*);
+void            begin_op();
+void            end_op();
 
 // mp.c
-extern int ismp;
-void mpinit(void);
+extern int      ismp;
+void            mpinit(void);
 
 // picirq.c
-void picenable(int);
-void picinit(void);
+void            picenable(int);
+void            picinit(void);
 
 // pipe.c
-
 int             pipealloc(struct file**, struct file**);
 void            pipeclose(struct pipe*, int);
 int             piperead(struct pipe*, char*, size_t);
@@ -164,7 +121,7 @@ struct cpu*     mycpu(void);
 struct proc*    myproc();
 void            pinit(void);
 void            procdump(void);
-[[noreturn]] void scheduler(void);
+void            scheduler(void) __attribute__((noreturn));
 void            sched(void);
 void            setproc(struct proc*);
 void            sleep(void*, struct spinlock*);
@@ -173,52 +130,25 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
-
-// PAGEBREAK: 16
-//  proc.c
-int cpuid(void);
-void exit(void);
-int fork(void);
-int growproc(int);
-int kill(int);
-struct cpu *mycpu(void);
-struct proc *myproc();
-void pinit(void);
-void procdump(void);
-void scheduler(void) __attribute__((noreturn));
-void sched(void);
-void setproc(struct proc *);
-void sleep(void *, struct spinlock *);
-void userinit(void);
-int wait(void);
-void wakeup(void *);
-void yield(void);
-
-
 // swtch.S
-void swtch(context_t **, context_t *);
+void            swtch(context_t**, context_t*);
 
 // spinlock.c
-void acquire(struct spinlock *);
-void getcallerpcs(void *, uint *);
-int holding(struct spinlock *);
-void initlock(struct spinlock *, char *);
-void release(struct spinlock *);
-void pushcli(void);
-void popcli(void);
+void            acquire(struct spinlock*);
+void            getcallerpcs(void*, uint*);
+int             holding(struct spinlock*);
+void            initlock(struct spinlock*, char*);
+void            release(struct spinlock*);
+void            pushcli(void);
+void            popcli(void);
 
 // sleeplock.c
-void acquiresleep(struct sleeplock *);
-void releasesleep(struct sleeplock *);
-int holdingsleep(struct sleeplock *);
-void initsleeplock(struct sleeplock *, char *);
+void            acquiresleep(struct sleeplock*);
+void            releasesleep(struct sleeplock*);
+int             holdingsleep(struct sleeplock*);
+void            initsleeplock(struct sleeplock*, char*);
 
 // string.c
-
 int             memcmp(const void*, const void*, size_t);
 void*           memmove(void*, const void*, size_t);
 void*           memset(void*, int, size_t);
@@ -235,61 +165,46 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
-
-// syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
-void syscall(void);
-
-
 // timer.c
-void timerinit(void);
+void            timerinit(void);
 
 // trap.c
-void idtinit(void);
-extern uint ticks;
-void tvinit(void);
+void            idtinit(void);
+extern uint     ticks;
+void            tvinit(void);
 extern struct spinlock tickslock;
 void            exo_pctr_transfer(struct trapframe *);
 
 // uart.c
-void uartinit(void);
-void uartintr(void);
-void uartputc(int);
+void            uartinit(void);
+void            uartintr(void);
+void            uartputc(int);
 
 // vm.c
-void seginit(void);
-void kvmalloc(void);
-pde_t *setupkvm(void);
+void            seginit(void);
+void            kvmalloc(void);
+pde_t*          setupkvm(void);
 #ifdef __x86_64__
-pml4e_t *setupkvm64(void);
+pml4e_t*        setupkvm64(void);
 #endif
-char *uva2ka(pde_t *, char *);
-int allocuvm(pde_t *, uint, uint);
-int deallocuvm(pde_t *, uint, uint);
-void freevm(pde_t *);
-void inituvm(pde_t *, char *, uint);
-int loaduvm(pde_t *, char *, struct inode *, uint, uint);
-pde_t *copyuvm(pde_t *, uint);
-void switchuvm(struct proc *);
-void switchkvm(void);
+char*           uva2ka(pde_t*, char*);
+int             allocuvm(pde_t*, uint, uint);
+int             deallocuvm(pde_t*, uint, uint);
+void            freevm(pde_t*);
+void            inituvm(pde_t*, char*, uint);
+int             loaduvm(pde_t*, char*, struct inode*, uint, uint);
+pde_t*          copyuvm(pde_t*, uint);
+void            switchuvm(struct proc*);
+void            switchkvm(void);
 #ifdef __x86_64__
-int copyout(pde_t *, uint64, void *, uint);
+int             copyout(pde_t*, uint64, void*, uint);
 #else
-int copyout(pde_t *, uint, void *, uint);
+int             copyout(pde_t*, uint, void*, uint);
 #endif
-
 void            clearpteu(pde_t *pgdir, char *uva);
+
+// number of elements in fixed-size array
+#define NELEM(x) (sizeof(x)/sizeof((x)[0]))
 #ifdef __x86_64__
 int             insert_pte(pde_t*, void*, uint64, int);
 #else
@@ -299,8 +214,3 @@ struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
-
-void clearpteu(pde_t *pgdir, char *uva);
-
-// number of elements in fixed-size array
-#define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,15 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/exo_cpu.h
+++ b/exo_cpu.h
@@ -38,4 +38,3 @@ static inline void cap_yield(context_t **old, context_t *target) {
   swtch(old, target);
 }
 
-#endif // EXO_CPU_H

--- a/math_core.c
+++ b/math_core.c
@@ -1,0 +1,36 @@
+#include "math_core.h"
+
+size_t
+phi_ring_size(size_t mu, size_t guard)
+{
+  double val = PHI_CONST * (double)mu;
+  size_t ceilv = (size_t)val;
+  if(val > (double)ceilv)
+    ceilv++;
+  return ceilv + guard;
+}
+
+uint
+fib(uint n)
+{
+  uint a = 0;
+  uint b = 1;
+  for(uint i = 0; i < n; i++){
+    uint t = a + b;
+    a = b;
+    b = t;
+  }
+  return a;
+}
+
+uint
+gcd(uint a, uint b)
+{
+  while(b != 0){
+    uint t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+

--- a/math_core.h
+++ b/math_core.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "types.h"
+
+#define PHI_CONST 1.6180339887498948482
+
+size_t phi_ring_size(size_t mu, size_t guard);
+uint fib(uint n);
+uint gcd(uint a, uint b);
+

--- a/phi.c
+++ b/phi.c
@@ -1,0 +1,29 @@
+#include "types.h"
+#include "stat.h"
+#include "user.h"
+#include "math_core.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc < 2){
+    printf(1, "usage: phi mu [guard]\n");
+    exit();
+  }
+  size_t mu = atoi(argv[1]);
+  size_t guard = 0;
+  if(argc > 2)
+    guard = atoi(argv[2]);
+
+  size_t s = phi_ring_size(mu, guard);
+  printf(1, "phi_ring_size(%d,%d)=%d\n", mu, guard, s);
+
+  uint k = 10;
+  uint m = 6;
+  uint fibk = fib(k);
+  uint gcdv = gcd(fibk, 1U << m);
+  printf(1, "gcd(Fib(%d),2^%d)=%d\n", k, m, gcdv);
+
+  exit();
+}
+

--- a/proc.h
+++ b/proc.h
@@ -79,8 +79,8 @@ struct proc {
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
-// Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+// Ensure scheduler and utilities rely on fixed proc size (136 bytes)
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -7,9 +7,7 @@
 #include "mmu.h"
 #include "param.h"
 #include "proc.h"
-#include "types.h"
 #include "x86.h"
-#include "syscall.h"
 // clang-format on
 
 
@@ -87,7 +85,6 @@ int argint(int n, int *ip) {
 int
 argptr(int n, char **pp, size_t size)
 {
-int argptr(int n, char **pp, int size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;

--- a/syscall.h
+++ b/syscall.h
@@ -22,12 +22,8 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
-#define SYS_mappte 22
 #define SYS_set_timer_upcall 22
 #define SYS_exo_alloc_page 23
 #define SYS_exo_unbind_page 24
 #define SYS_exo_alloc_block 25
 #define SYS_exo_bind_block 26
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
-

--- a/sysproc.c
+++ b/sysproc.c
@@ -83,6 +83,7 @@ sys_mappte(void)
     return -1;
   return insert_pte(myproc()->pgdir, (void *)va, pa, perm);
 
+}
 
 int sys_set_timer_upcall(void) {
   void (*handler)(void);

--- a/types.h
+++ b/types.h
@@ -6,31 +6,12 @@ typedef uint8_t  uchar;
 typedef uint16_t ushort;
 typedef uint32_t uint;
 typedef uint64_t uint64;
-
-#ifdef __x86_64__
-typedef uint64_t pde_t;
-typedef uint64_t uintptr_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-typedef signed long long int64;
-
-typedef unsigned int uint32_t;
-typedef int int32_t;
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-
-typedef unsigned long uintptr_t;
 typedef unsigned int size_t;
 
 #ifdef __x86_64__
 typedef unsigned long long pde_t;
+typedef unsigned long long uintptr_t;
 #else
-typedef uint32_t pde_t;
-typedef uint32_t uintptr_t;
+typedef unsigned int pde_t;
+typedef unsigned int uintptr_t;
 #endif

--- a/usys.S
+++ b/usys.S
@@ -38,7 +38,6 @@ SYSCALL(getpid)
 SYSCALL(sbrk)
 SYSCALL(sleep)
 SYSCALL(uptime)
-SYSCALL(mappte)
 
 
 #ifndef __x86_64__


### PR DESCRIPTION
## Summary
- add C23 math_core library with golden-ratio sizing helpers
- integrate library into user programs
- provide new `phi` example showing sizing and gcd(Fib,2^m) lemma
- fix Makefile extraneous `endif`
- clean up headers and prototypes so build passes

## Testing
- `make math_core.o`
- `make`
- `make _phi`
