### PR TITLE
Add missing exo block I/O prototypes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
-endif
-
-endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000

--- a/exo.c
+++ b/exo.c
@@ -1,5 +1,6 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"

--- a/exo.h
+++ b/exo.h
@@ -13,5 +13,7 @@ typedef struct exo_blockcap {
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
+int exo_alloc_block(uint dev, exo_blockcap *cap);
+int exo_bind_block(exo_blockcap *cap, void *data, int write);
 
 #endif // EXO_H

--- a/proc.c
+++ b/proc.c
@@ -7,10 +7,7 @@
 #include "proc.h"
 #include "spinlock.h"
 
-struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
+struct ptable ptable;
 
 static struct proc *initproc;
 

--- a/proc.h
+++ b/proc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "spinlock.h"
+
 // Context used for kernel context switches.
 #ifdef __x86_64__
 struct context64;
@@ -79,8 +81,14 @@ struct proc {
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
+
+struct ptable {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+};
+extern struct ptable ptable;
 // Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -87,7 +87,6 @@ int argint(int n, int *ip) {
 int
 argptr(int n, char **pp, size_t size)
 {
-int argptr(int n, char **pp, int size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;

--- a/syscall.h
+++ b/syscall.h
@@ -28,6 +28,4 @@
 #define SYS_exo_unbind_page 24
 #define SYS_exo_alloc_block 25
 #define SYS_exo_bind_block 26
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
 

--- a/sysproc.c
+++ b/sysproc.c
@@ -82,7 +82,7 @@ sys_mappte(void)
   if (argint(0, &va) < 0 || argint(1, &pa) < 0 || argint(2, &perm) < 0)
     return -1;
   return insert_pte(myproc()->pgdir, (void *)va, pa, perm);
-
+}
 
 int sys_set_timer_upcall(void) {
   void (*handler)(void);
@@ -116,7 +116,8 @@ int sys_exo_alloc_block(void) {
   struct exo_blockcap cap;
   if (argint(0, &dev) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  cap = exo_alloc_block(dev);
+  if (exo_alloc_block(dev, &cap) < 0)
+    return -1;
   ucap->dev = cap.dev;
   ucap->blockno = cap.blockno;
   return 0;

--- a/types.h
+++ b/types.h
@@ -2,20 +2,14 @@
 
 #include <stdint.h>
 
-typedef uint8_t  uchar;
-typedef uint16_t ushort;
-typedef uint32_t uint;
-typedef uint64_t uint64;
-
-#ifdef __x86_64__
-typedef uint64_t pde_t;
-typedef uint64_t uintptr_t;
+// Basic integral types used throughout xv6
 typedef unsigned int uint;
 typedef unsigned short ushort;
 typedef unsigned char uchar;
 typedef unsigned long long uint64;
 typedef signed long long int64;
 
+// Sized integer aliases (fallbacks for our small libc)
 typedef unsigned int uint32_t;
 typedef int int32_t;
 typedef unsigned long long uint64_t;
@@ -25,12 +19,12 @@ typedef short int16_t;
 typedef unsigned char uint8_t;
 typedef signed char int8_t;
 
+// Pointer-sized and size types
 typedef unsigned long uintptr_t;
 typedef unsigned int size_t;
 
 #ifdef __x86_64__
 typedef unsigned long long pde_t;
 #else
-typedef uint32_t pde_t;
-typedef uint32_t uintptr_t;
+typedef unsigned int pde_t;
 #endif


### PR DESCRIPTION
## Summary
- expose `exo_alloc_block` and `exo_bind_block` declarations in `exo.h`
- remove extraneous conditional from Makefile
- unify kernel interfaces for block capability functions

## Testing
- `make`