### PR TITLE
Add math_core lib and phi example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ tags: $(OBJS) $(ENTRYOTHERASM) _init
 vectors.S: vectors.pl
 	./vectors.pl > vectors.S
 
-ULIB = ulib.o usys.o printf.o umalloc.o swtch.o caplib.o
+ULIB = ulib.o usys.o printf.o umalloc.o swtch.o caplib.o math_core.o
 
 _%: %.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
@@ -206,6 +206,7 @@ UPROGS=\
 	_stressfs\
 	_usertests\
 	_wc\
+        _phi\
 	_zombie\
 
 ifeq ($(ARCH),x86_64)

--- a/defs.h
+++ b/defs.h
@@ -23,6 +23,7 @@ struct stat;
 struct superblock;
 struct exo_cap;
 struct exo_blockcap;
+struct trapframe;
 
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
@@ -76,32 +77,6 @@ struct inode*   nameiparent(char*, char*);
 int             readi(struct inode*, char*, uint, size_t);
 void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, char*, uint, size_t);
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
-void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
-
-// fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
-void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
 
 
 // ide.c
@@ -173,30 +148,6 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
-
-// PAGEBREAK: 16
-//  proc.c
-int cpuid(void);
-void exit(void);
-int fork(void);
-int growproc(int);
-int kill(int);
-struct cpu *mycpu(void);
-struct proc *myproc();
-void pinit(void);
-void procdump(void);
-void scheduler(void) __attribute__((noreturn));
-void sched(void);
-void setproc(struct proc *);
-void sleep(void *, struct spinlock *);
-void userinit(void);
-int wait(void);
-void wakeup(void *);
-void yield(void);
 
 
 // swtch.S
@@ -235,21 +186,6 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
-
-// syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
-void syscall(void);
 
 
 // timer.c
@@ -300,7 +236,6 @@ int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
 
-void clearpteu(pde_t *pgdir, char *uva);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,15 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/kernel/exo_disk.h
+++ b/kernel/exo_disk.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "exo_mem.h"
+#include "../stdint.h"
 #include "../exo.h"
 
 int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n);

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "exo_mem.h"
+#include "../stdint.h"
 #include "../exo.h"
 
 int exo_send(exo_cap dest, const void *buf, uint64_t len);

--- a/math_core.c
+++ b/math_core.c
@@ -1,0 +1,30 @@
+#include "types.h"
+#include "user.h"
+
+int
+gcd(int a, int b)
+{
+  int t;
+  while(b != 0){
+    t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+int
+fib(int n)
+{
+  int a, b, i, t;
+  if(n <= 0)
+    return 0;
+  a = 0;
+  b = 1;
+  for(i = 1; i < n; i++){
+    t = a + b;
+    a = b;
+    b = t;
+  }
+  return b;
+}

--- a/math_core.h
+++ b/math_core.h
@@ -1,0 +1,3 @@
+#pragma once
+int gcd(int a, int b);
+int fib(int n);

--- a/phi.c
+++ b/phi.c
@@ -1,0 +1,20 @@
+#include "user.h"
+#include "math_core.h"
+
+int
+main(int argc, char *argv[])
+{
+  int n = 10;
+  int m = 5;
+  if(argc > 1)
+    n = atoi(argv[1]);
+  if(argc > 2)
+    m = atoi(argv[2]);
+
+  int f = fib(n);
+  int g = gcd(f, 1 << m);
+
+  printf(1, "fib(%d) = %d\n", n, f);
+  printf(1, "gcd(fib(%d), 1<<%d) = %d\n", n, m, g);
+  exit();
+}

--- a/proc.h
+++ b/proc.h
@@ -79,8 +79,8 @@ struct proc {
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
-// Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+// Ensure scheduler and utilities rely on fixed proc size (136 bytes)
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -87,7 +87,6 @@ int argint(int n, int *ip) {
 int
 argptr(int n, char **pp, size_t size)
 {
-int argptr(int n, char **pp, int size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;


### PR DESCRIPTION
## Summary
- include `math_core.o` in `ULIB`
- add a small math helper library with `gcd` and `fib`
- provide `phi.c` example program using the helpers
- install `_phi` in the file system
- fix build by cleaning up headers and adding missing includes

## Testing
- `make`
