### PR TITLE
Fix header duplicates and build issues

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -23,6 +23,7 @@ struct stat;
 struct superblock;
 struct exo_cap;
 struct exo_blockcap;
+struct trapframe;
 
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
@@ -36,10 +37,6 @@ void brelse(struct buf *);
 void bwrite(struct buf *);
 
 // console.c
-void            consoleinit(void);
-void            cprintf(char*, ...);
-void            consoleintr(int(*)(void));
-[[noreturn]] void panic(char*);
 void consoleinit(void);
 void cprintf(char *, ...);
 void consoleintr(int (*)(void));
@@ -76,32 +73,6 @@ struct inode*   nameiparent(char*, char*);
 int             readi(struct inode*, char*, uint, size_t);
 void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, char*, uint, size_t);
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
-void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
-
-// fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
-void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
 
 
 // ide.c
@@ -173,30 +144,6 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
-
-// PAGEBREAK: 16
-//  proc.c
-int cpuid(void);
-void exit(void);
-int fork(void);
-int growproc(int);
-int kill(int);
-struct cpu *mycpu(void);
-struct proc *myproc();
-void pinit(void);
-void procdump(void);
-void scheduler(void) __attribute__((noreturn));
-void sched(void);
-void setproc(struct proc *);
-void sleep(void *, struct spinlock *);
-void userinit(void);
-int wait(void);
-void wakeup(void *);
-void yield(void);
 
 
 // swtch.S
@@ -235,21 +182,6 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
-
-// syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
-void syscall(void);
 
 
 // timer.c
@@ -299,8 +231,6 @@ struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
-
-void clearpteu(pde_t *pgdir, char *uva);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,15 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/kernel/exo_disk.h
+++ b/kernel/exo_disk.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "exo_mem.h"
 #include "../exo.h"
+#include <stdint.h>
 
 int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n);
 int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n);

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "exo_mem.h"
 #include "../exo.h"
+#include <stdint.h>
 
 int exo_send(exo_cap dest, const void *buf, uint64_t len);
 int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/proc.h
+++ b/proc.h
@@ -80,7 +80,8 @@ struct proc {
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
 // Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+// Size check for struct proc; update if layout changes
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -7,9 +7,7 @@
 #include "mmu.h"
 #include "param.h"
 #include "proc.h"
-#include "types.h"
 #include "x86.h"
-#include "syscall.h"
 // clang-format on
 
 
@@ -84,10 +82,7 @@ int argint(int n, int *ip) {
 // Fetch the nth word-sized system call argument as a pointer
 // to a block of memory of size bytes.  Check that the pointer
 // lies within the process address space.
-int
-argptr(int n, char **pp, size_t size)
-{
-int argptr(int n, char **pp, int size) {
+int argptr(int n, char **pp, size_t size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;


### PR DESCRIPTION
## Summary
- remove duplicate prototypes from `defs.h`
- include `<stdint.h>` in exo headers
- declare the process table for capability transfer
- update `struct proc` size check
- clean up `argptr` definition

## Testing
- `make`