### PR TITLE
Fix entry startup code copy for x86_64

### DIFF
--- a/exo.c
+++ b/exo.c
@@ -6,10 +6,7 @@
 #include "types.h"
 #include "x86.h"
 
-extern struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
+
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/main.c
+++ b/main.c
@@ -88,8 +88,6 @@ startothers(void)
 
   memmove(code, _binary_entryother64_start, (uint)_binary_entryother64_size);
 
-  memmove(code, _binary_entryother_start, (uint64)_binary_entryother_size);
-
 #else
   memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
 #endif

--- a/types.h
+++ b/types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
@@ -10,18 +9,10 @@ typedef uint64_t uint64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-
 typedef unsigned long uintptr_t;
 typedef unsigned long size_t;
 #else
-
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
-typedef uint32_t size_t
-typedef unsigned int pde_t;
-
+typedef uint32_t size_t;
 #endif


### PR DESCRIPTION
## Summary
- avoid copying the 32-bit entry code when starting APs on x86_64
- clean up architecture-specific typedefs
- remove unused ptable declaration in exo.c

## Testing
- `make`
