### PR TITLE
Check AP stack allocation failure

### DIFF
--- a/exo.c
+++ b/exo.c
@@ -6,11 +6,6 @@
 #include "types.h"
 #include "x86.h"
 
-extern struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
-
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;
   struct proc *p;

--- a/main.c
+++ b/main.c
@@ -102,6 +102,8 @@ startothers(void)
     // pgdir to use. We cannot use kpgdir yet, because the AP processor
     // is running in low  memory, so we use entrypgdir for the APs too.
     stack = kalloc();
+    if(stack == 0)
+      panic("startothers: out of memory");
 #ifdef __x86_64__
     *(uint64*)(code-8) = (uint64)stack + KSTACKSIZE;
     *(void(**)(void))(code-16) = mpenter;

--- a/types.h
+++ b/types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
@@ -10,18 +9,10 @@ typedef uint64_t uint64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-
 typedef unsigned long uintptr_t;
 typedef unsigned long size_t;
 #else
-
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
-typedef uint32_t size_t
-typedef unsigned int pde_t;
-
+typedef uint32_t size_t;
 #endif


### PR DESCRIPTION
## Summary
- validate that `kalloc()` succeeded in `startothers`
- remove duplicate declarations in `types.h`
- use existing `ptable` from `proc.c` in `exo.c`

## Testing
- `make -j1`