### PR TITLE
Add enum member support in runoff

### DIFF
--- a/exo.c
+++ b/exo.c
@@ -6,10 +6,6 @@
 #include "types.h"
 #include "x86.h"
 
-extern struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/runoff
+++ b/runoff
@@ -115,8 +115,9 @@ perl -e '
 # make definition list
 cd fmt
 perl -e '
-	while(<>) {
-		chomp;
+        $in_enum = 0;
+        while(<>) {
+                chomp;
 
 		s!//.*!!;
 		s!/\*([^*]|[*][^/])*\*/!!g;
@@ -154,14 +155,58 @@ perl -e '
 			next;
 		}
 
-		if (/^([0-9]+) (((static|struct|extern|union|enum) +)*([A-Za-z0-9_]+))( .*)? +([A-Za-z_][A-Za-z0-9_]*)(,|;|=| =)/) {
-			print "$1 $7\n";
-		}
-		
-		elsif(/^([0-9]+) (enum|struct|union) +([A-Za-z0-9_]+) +{/){ 
-			print "$1 $3\n";
-		}
-		# TODO: enum members
+                if($in_enum){
+                        ($ln) = /^([0-9]+)/;
+                        $rest = $_;
+                        $rest =~ s/^\d+ //;
+                        $end = ($rest =~ /}/);
+                        $rest =~ s/}.*//;
+                        foreach $m (split /,/, $rest){
+                                $m =~ s/=.*//;
+                                $m =~ s/^\s+//; $m =~ s/\s+$//;
+                                if($m =~ /^[A-Za-z_][A-Za-z0-9_]*$/){
+                                        print "$ln $m\n";
+                                }
+                        }
+                        $in_enum = 0 if $end;
+                        next;
+                }
+
+                if (/^([0-9]+) (((static|struct|extern|union|enum) +)*([A-Za-z0-9_]+))( .*)? +([A-Za-z_][A-Za-z0-9_]*)(,|;|=| =)/) {
+                        $ln = $1;
+                        print "$ln $7\n";
+                        $tmp = $_;
+                        $tmp =~ s/^\d+ //;
+                        if($tmp =~ /\benum\b[^\{]*{(.*)/){
+                                $rest = $1;
+                                $end = ($rest =~ /}/);
+                                $rest =~ s/}.*//;
+                                foreach $m (split /,/, $rest){
+                                        $m =~ s/=.*//;
+                                        $m =~ s/^\s+//; $m =~ s/\s+$//;
+                                        if($m =~ /^[A-Za-z_][A-Za-z0-9_]*$/){
+                                                print "$ln $m\n";
+                                        }
+                                }
+                                $in_enum = 1 unless $end;
+                        }
+                }
+
+                elsif(/^([0-9]+) (enum|struct|union) +([A-Za-z0-9_]+) +{(.*)/){
+                        $ln = $1;
+                        print "$ln $3\n";
+                        $rest = $4;
+                        $end = ($rest =~ /}/);
+                        $rest =~ s/}.*//;
+                        foreach $m (split /,/, $rest){
+                                $m =~ s/=.*//;
+                                $m =~ s/^\s+//; $m =~ s/\s+$//;
+                                if($m =~ /^[A-Za-z_][A-Za-z0-9_]*$/){
+                                        print "$ln $m\n";
+                                }
+                        }
+                        $in_enum = 1 unless $end;
+                }
 	}
 ' $files >defs
 

--- a/toc.ftr
+++ b/toc.ftr
@@ -1,7 +1,7 @@
 
 
-The source listing is preceded by a cross-reference that lists every defined 
-constant, struct, global variable, and function in xv6.  Each entry gives,
+The source listing is preceded by a cross-reference that lists every defined
+constant, struct, enum (with member names), global variable, and function in xv6.  Each entry gives,
 on the same line as the name, the line number (or, in a few cases, numbers)
 where the name is defined.  Successive lines in an entry list the line
 numbers where the name is used.  For example, this entry:

--- a/types.h
+++ b/types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
@@ -10,18 +9,10 @@ typedef uint64_t uint64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-
 typedef unsigned long uintptr_t;
 typedef unsigned long size_t;
 #else
-
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
-typedef uint32_t size_t
-typedef unsigned int pde_t;
-
+typedef uint32_t size_t;
 #endif


### PR DESCRIPTION
## Summary
- extend runoff parsing to output enum member definitions
- document enum handling in cross-reference docs
- fix build by restoring `types.h` and removing redundant ptable declaration

## Testing
- `make clean`
- `make`
