### PR TITLE
Add capability disk and yield syscall wrappers

### DIFF
--- a/caplib.c
+++ b/caplib.c
@@ -19,3 +19,13 @@ int cap_set_timer(void (*handler)(void)) { return set_timer_upcall(handler); }
 void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);
 }
+
+int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
+
+int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n) {
+  return exo_read_disk(cap, dst, off, n);
+}
+
+int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n) {
+  return exo_write_disk(cap, src, off, n);
+}

--- a/caplib.h
+++ b/caplib.h
@@ -8,3 +8,6 @@ int cap_alloc_block(uint dev, exo_blockcap *cap);
 int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_set_timer(void (*handler)(void));
 void cap_yield_to(context_t **old, context_t *target);
+int cap_yield_to_cap(exo_cap target);
+int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
+int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);

--- a/exo.c
+++ b/exo.c
@@ -6,10 +6,7 @@
 #include "types.h"
 #include "x86.h"
 
-extern struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
+extern struct ptable ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;
@@ -23,4 +20,34 @@ void exo_pctr_transfer(struct trapframe *tf) {
     }
   }
   release(&ptable.lock);
+}
+
+// Stubs for capability syscalls. Real implementations may reside in
+// platform-specific code, but we provide simple versions so that the
+// kernel links successfully.
+int
+exo_yield_to(exo_cap target)
+{
+  (void)target;
+  return -1;
+}
+
+int
+exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
+{
+  (void)cap;
+  (void)dst;
+  (void)off;
+  (void)n;
+  return -1;
+}
+
+int
+exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n)
+{
+  (void)cap;
+  (void)src;
+  (void)off;
+  (void)n;
+  return -1;
 }

--- a/syscall.c
+++ b/syscall.c
@@ -153,6 +153,9 @@ extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
 extern int sys_exo_alloc_block(void);
 extern int sys_exo_bind_block(void);
+extern int sys_exo_yield_to(void);
+extern int sys_exo_read_disk(void);
+extern int sys_exo_write_disk(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -182,6 +185,9 @@ static int (*syscalls[])(void) = {
     [SYS_exo_unbind_page] sys_exo_unbind_page,
     [SYS_exo_alloc_block] sys_exo_alloc_block,
     [SYS_exo_bind_block] sys_exo_bind_block,
+    [SYS_exo_yield_to] sys_exo_yield_to,
+    [SYS_exo_read_disk] sys_exo_read_disk,
+    [SYS_exo_write_disk] sys_exo_write_disk,
 };
 
 void syscall(void) {

--- a/syscall.h
+++ b/syscall.h
@@ -28,4 +28,7 @@
 #define SYS_exo_unbind_page 25
 #define SYS_exo_alloc_block 26
 #define SYS_exo_bind_block 27
+#define SYS_exo_yield_to 28
+#define SYS_exo_read_disk 29
+#define SYS_exo_write_disk 30
 

--- a/sysproc.c
+++ b/sysproc.c
@@ -144,3 +144,34 @@ int sys_exo_bind_block(void) {
   releasesleep(&b.lock);
   return 0;
 }
+
+int sys_exo_yield_to(void) {
+  exo_cap cap;
+  if (argint(0, (int *)&cap.pa) < 0)
+    return -1;
+  return exo_yield_to(cap);
+}
+
+int sys_exo_read_disk(void) {
+  exo_cap cap;
+  char *dst;
+  uint off, n;
+  if (argint(0, (int *)&cap.pa) < 0 ||
+      argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 ||
+      argptr(1, &dst, n) < 0)
+    return -1;
+  return exo_read_disk(cap, dst, off, n);
+}
+
+int sys_exo_write_disk(void) {
+  exo_cap cap;
+  char *src;
+  uint off, n;
+  if (argint(0, (int *)&cap.pa) < 0 ||
+      argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 ||
+      argptr(1, &src, n) < 0)
+    return -1;
+  return exo_write_disk(cap, src, off, n);
+}

--- a/types.h
+++ b/types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
@@ -10,18 +9,10 @@ typedef uint64_t uint64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-
 typedef unsigned long uintptr_t;
 typedef unsigned long size_t;
 #else
-
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
-typedef uint32_t size_t
-typedef unsigned int pde_t;
-
+typedef uint32_t size_t;
 #endif

--- a/user.h
+++ b/user.h
@@ -38,6 +38,9 @@ exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
+int exo_yield_to(exo_cap target);
+int exo_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
+int exo_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
 
 
 // ulib.c

--- a/usys.S
+++ b/usys.S
@@ -60,5 +60,8 @@ SYSCALL(exo_alloc_page)
 SYSCALL(exo_unbind_page)
 SYSCALL(exo_alloc_block)
 SYSCALL(exo_bind_block)
+SYSCALL(exo_yield_to)
+SYSCALL(exo_read_disk)
+SYSCALL(exo_write_disk)
 
 


### PR DESCRIPTION
## Summary
- provide assembly stubs for `exo_yield_to`, `exo_read_disk`, and `exo_write_disk`
- add sysproc handlers for the new capability syscalls
- extend syscall table with the new entries
- expose new functions through user and capability libraries
- fix malformed `types.h` and update `exo.c` with syscall stubs

## Testing
- `make --quiet kernel`