### PR TITLE
Remove duplicate exo stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,9 @@ OBJS = \
 	uart.o\
 	vectors.o\
         vm.o\
-        exo.o\
-        exo/exo_cpu.o\
-        exo/exo_disk.o\
-        exo/exo_ipc.o\
-        exo_stream.o\
+       exo.o\
+       exo/exo_ipc.o\
+       exo_stream.o\
         kernel/exo_cpu.o\
         kernel/exo_disk.o\
 

--- a/caplib.c
+++ b/caplib.c
@@ -22,10 +22,10 @@ void cap_yield_to(context_t **old, context_t *target) {
 
 int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
 
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n) {
+int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n) {
   return exo_read_disk(cap, dst, off, n);
 }
 
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n) {
+int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n) {
   return exo_write_disk(cap, src, off, n);
 }

--- a/caplib.h
+++ b/caplib.h
@@ -9,5 +9,5 @@ int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_set_timer(void (*handler)(void));
 void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
+int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);

--- a/exo.c
+++ b/exo.c
@@ -25,15 +25,15 @@ void exo_pctr_transfer(struct trapframe *tf) {
 // Stubs for capability syscalls. Real implementations may reside in
 // platform-specific code, but we provide simple versions so that the
 // kernel links successfully.
-int
+int __attribute__((weak))
 exo_yield_to(exo_cap target)
 {
   (void)target;
   return -1;
 }
 
-int
-exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
+int __attribute__((weak))
+exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 {
   (void)cap;
   (void)dst;
@@ -42,8 +42,8 @@ exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
   return -1;
 }
 
-int
-exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n)
+int __attribute__((weak))
+exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
 {
   (void)cap;
   (void)src;

--- a/exo/exo_cpu.c
+++ b/exo/exo_cpu.c
@@ -1,7 +1,7 @@
 #include "defs.h"
 #include "kernel/exo_cpu.h"
 
-int exo_yield_to(exo_cap target) {
+int __attribute__((weak)) exo_yield_to(exo_cap target) {
     // TODO: implement context switch to the capability
     (void)target;
     return -1;

--- a/exo/exo_disk.c
+++ b/exo/exo_disk.c
@@ -1,13 +1,13 @@
 #include "defs.h"
 #include "kernel/exo_disk.h"
 
-int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n) {
+int __attribute__((weak)) exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n) {
     // TODO: implement disk read via capability
     (void)cap; (void)dst; (void)off; (void)n;
     return -1;
 }
 
-int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n) {
+int __attribute__((weak)) exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n) {
     // TODO: implement disk write via capability
     (void)cap; (void)src; (void)off; (void)n;
     return -1;

--- a/exo/exo_ipc.c
+++ b/exo/exo_ipc.c
@@ -1,13 +1,13 @@
 #include "defs.h"
 #include "kernel/exo_ipc.h"
 
-int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+int __attribute__((weak)) exo_send(exo_cap dest, const void *buf, uint64_t len) {
     // TODO: implement IPC send
     (void)dest; (void)buf; (void)len;
     return -1;
 }
 
-int exo_recv(exo_cap src, void *buf, uint64_t len) {
+int __attribute__((weak)) exo_recv(exo_cap src, void *buf, uint64_t len) {
     // TODO: implement IPC receive
     (void)src; (void)buf; (void)len;
     return -1;

--- a/sysproc.c
+++ b/sysproc.c
@@ -153,10 +153,10 @@ int sys_exo_yield_to(void) {
 }
 
 int sys_exo_read_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *dst;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
       argint(3, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
@@ -165,10 +165,10 @@ int sys_exo_read_disk(void) {
 }
 
 int sys_exo_write_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *src;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
       argint(3, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)

--- a/user.h
+++ b/user.h
@@ -39,8 +39,8 @@ int exo_unbind_page(exo_cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_yield_to(exo_cap target);
-int exo_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int exo_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
+int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 
 
 // ulib.c


### PR DESCRIPTION
## Summary
- mark all capability stubs with `__attribute__((weak))`
- use kernel version of disk capability prototypes
- drop exo/exo_cpu.o and exo/exo_disk.o from the kernel build
- update user headers and library for new prototypes

## Testing
- `make clean`
- `make`