### PR TITLE
Fix syscall trap selectors

### DIFF
--- a/arch/x64/entry64.S
+++ b/arch/x64/entry64.S
@@ -67,12 +67,15 @@ syscallentry:
     pushq %rax
     # trap number and minimal frame information
     pushq $T_SYSCALL
-    pushq $0
+    pushq $0          # dummy error code
     pushq %rcx        # saved RIP from RCX
-    pushq $0          # CS placeholder
+    pushq $(SEG_KCODE<<3) # CS = 0x08, kernel code segment
     pushq %r11        # EFLAGS from R11
     pushq %rsp        # current RSP (approximate)
-    pushq $0          # SS placeholder
+    pushq $(SEG_KDATA<<3) # SS = 0x10, kernel stack segment
+    # Trap frame layout now matches struct trapframe in trap.c:
+    # r15..r8, rdi, rsi, rbp, rbx, rdx, rcx, rax,
+    # trapno, err, rip, cs, eflags, rsp, ss
 
     movq %rsp, %rdi   # argument: pointer to trap frame
     call trap


### PR DESCRIPTION
## Summary
- correct CS and SS selector values in `syscallentry`
- comment trap frame layout for 64-bit syscall path

## Testing
- `make` *(fails: incompatible type for exo_read_disk in sysproc.c)*