### PR TITLE
Implement basic IPC syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ OBJS = \
         exo_stream.o\
         kernel/exo_cpu.o\
         kernel/exo_disk.o\
+        kernel/exo_ipc.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += mmu64.o
@@ -219,6 +220,7 @@ UPROGS=\
         _zombie\
         _phi\
         _exo_stream_demo\
+        _ipc_test\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/caplib.c
+++ b/caplib.c
@@ -29,3 +29,11 @@ int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n) {
 int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n) {
   return exo_write_disk(cap, src, off, n);
 }
+
+int cap_send(exo_cap dest, const void *buf, uint64 len) {
+  return exo_send(dest, buf, len);
+}
+
+int cap_recv(exo_cap src, void *buf, uint64 len) {
+  return exo_recv(src, buf, len);
+}

--- a/caplib.h
+++ b/caplib.h
@@ -11,3 +11,5 @@ void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
 int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int cap_send(exo_cap dest, const void *buf, uint64 len);
+int cap_recv(exo_cap src, void *buf, uint64 len);

--- a/exo.c
+++ b/exo.c
@@ -33,7 +33,7 @@ exo_yield_to(exo_cap target)
 }
 
 int
-exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
+exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 {
   (void)cap;
   (void)dst;
@@ -43,11 +43,29 @@ exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
 }
 
 int
-exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n)
+exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
 {
   (void)cap;
   (void)src;
   (void)off;
   (void)n;
+  return -1;
+}
+
+int
+exo_send(exo_cap dest, const void *buf, uint64_t len)
+{
+  (void)dest;
+  (void)buf;
+  (void)len;
+  return -1;
+}
+
+int
+exo_recv(exo_cap src, void *buf, uint64_t len)
+{
+  (void)src;
+  (void)buf;
+  (void)len;
   return -1;
 }

--- a/exo/exo_disk.c
+++ b/exo/exo_disk.c
@@ -1,13 +1,13 @@
 #include "defs.h"
 #include "kernel/exo_disk.h"
 
-int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n) {
+int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n) {
     // TODO: implement disk read via capability
     (void)cap; (void)dst; (void)off; (void)n;
     return -1;
 }
 
-int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n) {
+int exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n) {
     // TODO: implement disk write via capability
     (void)cap; (void)src; (void)off; (void)n;
     return -1;

--- a/ipc_test.c
+++ b/ipc_test.c
@@ -1,0 +1,17 @@
+#include "caplib.h"
+#include "types.h"
+#include "user.h"
+
+int
+main(int argc, char *argv[])
+{
+  (void)argc; (void)argv;
+  char buf[16];
+  const char *msg = "hello";
+  exo_cap cap = {0};
+  cap_send(cap, msg, 5);
+  cap_recv(cap, buf, 5);
+  buf[5] = '\0';
+  printf(1, "ipc recv: %s\n", buf);
+  exit();
+}

--- a/kernel/exo_ipc.c
+++ b/kernel/exo_ipc.c
@@ -1,0 +1,65 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "kernel/exo_ipc.h"
+
+#define IPC_BUFSZ 128
+
+struct ipc_state {
+  struct spinlock lock;
+  char buf[IPC_BUFSZ];
+  size_t r;
+  size_t w;
+  int inited;
+};
+
+static struct ipc_state ipcs;
+
+static void
+ipc_init(void)
+{
+  if(!ipcs.inited){
+    initlock(&ipcs.lock, "exoipc");
+    ipcs.r = ipcs.w = 0;
+    ipcs.inited = 1;
+  }
+}
+
+int
+exo_send(exo_cap dest, const void *buf, uint64_t len)
+{
+  (void)dest;
+  ipc_init();
+  acquire(&ipcs.lock);
+  for(size_t i = 0; i < len; i++){
+    while(ipcs.w - ipcs.r == IPC_BUFSZ){
+      wakeup(&ipcs.r);
+      sleep(&ipcs.w, &ipcs.lock);
+    }
+    ipcs.buf[ipcs.w % IPC_BUFSZ] = ((const char*)buf)[i];
+    ipcs.w++;
+  }
+  wakeup(&ipcs.r);
+  release(&ipcs.lock);
+  return (int)len;
+}
+
+int
+exo_recv(exo_cap src, void *buf, uint64_t len)
+{
+  (void)src;
+  ipc_init();
+  acquire(&ipcs.lock);
+  for(size_t i = 0; i < len; i++){
+    while(ipcs.r == ipcs.w){
+      wakeup(&ipcs.w);
+      sleep(&ipcs.r, &ipcs.lock);
+    }
+    ((char*)buf)[i] = ipcs.buf[ipcs.r % IPC_BUFSZ];
+    ipcs.r++;
+  }
+  wakeup(&ipcs.w);
+  release(&ipcs.lock);
+  return (int)len;
+}

--- a/syscall.c
+++ b/syscall.c
@@ -156,6 +156,8 @@ extern int sys_exo_bind_block(void);
 extern int sys_exo_yield_to(void);
 extern int sys_exo_read_disk(void);
 extern int sys_exo_write_disk(void);
+extern int sys_exo_send(void);
+extern int sys_exo_recv(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -188,6 +190,8 @@ static int (*syscalls[])(void) = {
     [SYS_exo_yield_to] sys_exo_yield_to,
     [SYS_exo_read_disk] sys_exo_read_disk,
     [SYS_exo_write_disk] sys_exo_write_disk,
+    [SYS_exo_send] sys_exo_send,
+    [SYS_exo_recv] sys_exo_recv,
 };
 
 void syscall(void) {

--- a/syscall.h
+++ b/syscall.h
@@ -31,4 +31,6 @@
 #define SYS_exo_yield_to 28
 #define SYS_exo_read_disk 29
 #define SYS_exo_write_disk 30
+#define SYS_exo_send 31
+#define SYS_exo_recv 32
 

--- a/sysproc.c
+++ b/sysproc.c
@@ -153,10 +153,10 @@ int sys_exo_yield_to(void) {
 }
 
 int sys_exo_read_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *dst;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
       argint(3, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
@@ -165,13 +165,35 @@ int sys_exo_read_disk(void) {
 }
 
 int sys_exo_write_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *src;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
       argint(3, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)
     return -1;
   return exo_write_disk(cap, src, off, n);
+}
+
+int sys_exo_send(void) {
+  exo_cap cap;
+  char *src;
+  uint n;
+  if (argint(0, (int *)&cap.pa) < 0 ||
+      argint(2, (int *)&n) < 0 ||
+      argptr(1, &src, n) < 0)
+    return -1;
+  return exo_send(cap, src, n);
+}
+
+int sys_exo_recv(void) {
+  exo_cap cap;
+  char *dst;
+  uint n;
+  if (argint(0, (int *)&cap.pa) < 0 ||
+      argint(2, (int *)&n) < 0 ||
+      argptr(1, &dst, n) < 0)
+    return -1;
+  return exo_recv(cap, dst, n);
 }

--- a/user.h
+++ b/user.h
@@ -41,6 +41,8 @@ int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_yield_to(exo_cap target);
 int exo_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int exo_send(exo_cap dest, const void *buf, uint64 len);
+int exo_recv(exo_cap src, void *buf, uint64 len);
 
 
 // ulib.c

--- a/usys.S
+++ b/usys.S
@@ -63,5 +63,7 @@ SYSCALL(exo_bind_block)
 SYSCALL(exo_yield_to)
 SYSCALL(exo_read_disk)
 SYSCALL(exo_write_disk)
+SYSCALL(exo_send)
+SYSCALL(exo_recv)
 
 


### PR DESCRIPTION
## Summary
- add kernel message queue implementation in `exo_send`/`exo_recv`
- wire up new system calls and user wrappers
- provide capability helpers and IPC test program

## Testing
- `make _ipc_test`