### PR TITLE
Protect exo stream with spinlock

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,3 @@
 BasedOnStyle: LLVM
-Language: C
-Standard: c23
 IndentWidth: 2
 

--- a/caplib.c
+++ b/caplib.c
@@ -22,10 +22,10 @@ void cap_yield_to(context_t **old, context_t *target) {
 
 int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
 
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n) {
+int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n) {
   return exo_read_disk(cap, dst, off, n);
 }
 
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n) {
+int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n) {
   return exo_write_disk(cap, src, off, n);
 }

--- a/caplib.h
+++ b/caplib.h
@@ -9,5 +9,5 @@ int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_set_timer(void (*handler)(void));
 void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
+int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);

--- a/exo.c
+++ b/exo.c
@@ -1,6 +1,6 @@
 #include "defs.h"
-#include "param.h"
 #include "mmu.h"
+#include "param.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
@@ -25,16 +25,13 @@ void exo_pctr_transfer(struct trapframe *tf) {
 // Stubs for capability syscalls. Real implementations may reside in
 // platform-specific code, but we provide simple versions so that the
 // kernel links successfully.
-int
-exo_yield_to(exo_cap target)
-{
+int __attribute__((weak)) exo_yield_to(exo_cap target) {
   (void)target;
   return -1;
 }
 
-int
-exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
-{
+int __attribute__((weak)) exo_read_disk(exo_blockcap cap, void *dst,
+                                        uint64_t off, uint64_t n) {
   (void)cap;
   (void)dst;
   (void)off;
@@ -42,9 +39,8 @@ exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n)
   return -1;
 }
 
-int
-exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n)
-{
+int __attribute__((weak)) exo_write_disk(exo_blockcap cap, const void *src,
+                                         uint64_t off, uint64_t n) {
   (void)cap;
   (void)src;
   (void)off;

--- a/exo/exo_cpu.c
+++ b/exo/exo_cpu.c
@@ -1,8 +1,8 @@
-#include "defs.h"
 #include "kernel/exo_cpu.h"
+#include "defs.h"
 
-int exo_yield_to(exo_cap target) {
-    // TODO: implement context switch to the capability
-    (void)target;
-    return -1;
+int __attribute__((weak)) exo_yield_to(exo_cap target) {
+  // TODO: implement context switch to the capability
+  (void)target;
+  return -1;
 }

--- a/exo/exo_disk.c
+++ b/exo/exo_disk.c
@@ -1,14 +1,23 @@
-#include "defs.h"
 #include "kernel/exo_disk.h"
+#include "defs.h"
 
-int exo_read_disk(exo_cap cap, void *dst, uint64_t off, uint64_t n) {
-    // TODO: implement disk read via capability
-    (void)cap; (void)dst; (void)off; (void)n;
-    return -1;
+int __attribute__((weak)) exo_read_disk(struct exo_blockcap cap, void *dst,
+                                        uint64_t off, uint64_t n) {
+  // TODO: implement disk read via capability
+  (void)cap;
+  (void)dst;
+  (void)off;
+  (void)n;
+  return -1;
 }
 
-int exo_write_disk(exo_cap cap, const void *src, uint64_t off, uint64_t n) {
-    // TODO: implement disk write via capability
-    (void)cap; (void)src; (void)off; (void)n;
-    return -1;
+int __attribute__((weak)) exo_write_disk(struct exo_blockcap cap,
+                                         const void *src, uint64_t off,
+                                         uint64_t n) {
+  // TODO: implement disk write via capability
+  (void)cap;
+  (void)src;
+  (void)off;
+  (void)n;
+  return -1;
 }

--- a/exo_stream.c
+++ b/exo_stream.c
@@ -3,29 +3,46 @@
 #include "spinlock.h"
 
 static struct exo_stream *active_stream;
+static struct spinlock streamlock;
 
-void exo_stream_register(struct exo_stream *stream) { active_stream = stream; }
+void exo_stream_register(struct exo_stream *stream) {
+  static int inited;
+  if (!inited) {
+    initlock(&streamlock, "stream");
+    inited = 1;
+  }
+  acquire(&streamlock);
+  active_stream = stream;
+  release(&streamlock);
+}
 
 static void default_halt(void) { asm volatile("hlt"); }
 
 void exo_stream_halt(void) {
   struct exo_sched_ops *m;
 
+  acquire(&streamlock);
   if (!active_stream) {
+    release(&streamlock);
     default_halt();
     return;
   }
   for (m = active_stream->head; m; m = m->next)
     if (m->halt)
       m->halt();
+  release(&streamlock);
 }
 
 void exo_stream_yield(void) {
   struct exo_sched_ops *m;
 
-  if (!active_stream)
+  acquire(&streamlock);
+  if (!active_stream) {
+    release(&streamlock);
     return;
+  }
   for (m = active_stream->head; m; m = m->next)
     if (m->yield)
       m->yield();
+  release(&streamlock);
 }

--- a/exo_stream.h
+++ b/exo_stream.h
@@ -11,6 +11,12 @@ struct exo_stream {
   struct exo_sched_ops *head;
 };
 
+/*
+ * Access to the global active stream pointer is protected by a spinlock
+ * defined in exo_stream.c.  The register, halt and yield helpers acquire
+ * and release this lock internally.
+ */
+
 void exo_stream_register(struct exo_stream *stream);
 void exo_stream_halt(void);
 void exo_stream_yield(void);

--- a/sysproc.c
+++ b/sysproc.c
@@ -1,17 +1,18 @@
-#include "defs.h"
+// clang-format off
+#include "types.h"
 #include "date.h"
+#include "defs.h"
+#include "exo.h"
+#include "fs.h"
+#include "sleeplock.h"
+#include "buf.h"
 #include "memlayout.h"
 #include "mmu.h"
 #include "param.h"
 #include "proc.h"
-#include "types.h"
-#include "x86.h"
-#include "exo.h"
-#include "fs.h"
 #include "spinlock.h"
-#include "sleeplock.h"
-#include "buf.h"
-
+#include "x86.h"
+// clang-format on
 
 int sys_fork(void) { return fork(); }
 
@@ -74,9 +75,7 @@ int sys_uptime(void) {
   return xticks;
 }
 
-int
-sys_mappte(void)
-{
+int sys_mappte(void) {
   int va, pa, perm;
 
   if (argint(0, &va) < 0 || argint(1, &pa) < 0 || argint(2, &perm) < 0)
@@ -93,19 +92,15 @@ int sys_set_timer_upcall(void) {
 }
 
 // allocate a physical page and return its capability
-int
-sys_exo_alloc_page(void)
-{
+int sys_exo_alloc_page(void) {
   exo_cap cap = exo_alloc_page();
   return cap.pa;
 }
 
 // unbind and free a physical page by capability
-int
-sys_exo_unbind_page(void)
-{
+int sys_exo_unbind_page(void) {
   exo_cap cap;
-  if(argint(0, (int*)&cap.pa) < 0)
+  if (argint(0, (int *)&cap.pa) < 0)
     return -1;
   return exo_unbind_page(cap);
 }
@@ -153,25 +148,21 @@ int sys_exo_yield_to(void) {
 }
 
 int sys_exo_read_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *dst;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
-      argint(2, (int *)&off) < 0 ||
-      argint(3, (int *)&n) < 0 ||
-      argptr(1, &dst, n) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 || argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 || argptr(1, &dst, n) < 0)
     return -1;
   return exo_read_disk(cap, dst, off, n);
 }
 
 int sys_exo_write_disk(void) {
-  exo_cap cap;
+  struct exo_blockcap cap;
   char *src;
   uint off, n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
-      argint(2, (int *)&off) < 0 ||
-      argint(3, (int *)&n) < 0 ||
-      argptr(1, &src, n) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 || argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 || argptr(1, &src, n) < 0)
     return -1;
   return exo_write_disk(cap, src, off, n);
 }

--- a/user.h
+++ b/user.h
@@ -3,30 +3,29 @@
 struct stat;
 struct rtcdate;
 
-#include "exo_cpu.h"
 #include "exo.h"
-
+#include "exo_cpu.h"
 
 // system calls
 int fork(void);
 [[noreturn]] int exit(void);
 int wait(void);
-int pipe(int*);
-int write(int, const void*, size_t);
-int read(int, void*, size_t);
+int pipe(int *);
+int write(int, const void *, size_t);
+int read(int, void *, size_t);
 int close(int);
 int kill(int);
-int exec(char*, char**);
-int open(const char*, int);
-int mknod(const char*, short, short);
-int unlink(const char*);
-int fstat(int fd, struct stat*);
-int link(const char*, const char*);
-int mkdir(const char*);
-int chdir(const char*);
+int exec(char *, char **);
+int open(const char *, int);
+int mknod(const char *, short, short);
+int unlink(const char *);
+int fstat(int fd, struct stat *);
+int link(const char *, const char *);
+int mkdir(const char *);
+int chdir(const char *);
 int dup(int);
 int getpid(void);
-char* sbrk(int);
+char *sbrk(int);
 int sleep(int);
 int uptime(void);
 int mappte(void *, void *, int);
@@ -39,20 +38,19 @@ int exo_unbind_page(exo_cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_yield_to(exo_cap target);
-int exo_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int exo_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
-
+int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
+int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 
 // ulib.c
-int stat(const char*, struct stat*);
-char* strcpy(char*, const char*);
-void *memmove(void*, const void*, size_t);
-char* strchr(const char*, char c);
-int strcmp(const char*, const char*);
-void printf(int, const char*, ...);
-char* gets(char*, size_t max);
-size_t strlen(const char*);
-void* memset(void*, int, size_t);
-void* malloc(size_t);
-void free(void*);
-int atoi(const char*);
+int stat(const char *, struct stat *);
+char *strcpy(char *, const char *);
+void *memmove(void *, const void *, size_t);
+char *strchr(const char *, char c);
+int strcmp(const char *, const char *);
+void printf(int, const char *, ...);
+char *gets(char *, size_t max);
+size_t strlen(const char *);
+void *memset(void *, int, size_t);
+void *malloc(size_t);
+void free(void *);
+int atoi(const char *);


### PR DESCRIPTION
## Summary
- add `streamlock` spinlock to exo_stream.c
- guard accesses to `active_stream` with this lock
- document locking in exo_stream.h
- fix disk capability functions and weak stubs
- ensure build succeeds and clang-format runs

## Testing
- `clang-format -i caplib.c caplib.h exo.c exo/exo_disk.c exo/exo_cpu.c sysproc.c user.h exo_stream.c exo_stream.h`
- `make -j2`