### PR TITLE
Attempt x86_64 build fixes

### DIFF
--- a/arch/x64/bootasm64.S
+++ b/arch/x64/bootasm64.S
@@ -6,12 +6,7 @@
 
 # Segments for protected mode (32-bit) and long mode (64-bit)
 
-# Helper to build a 64-bit segment descriptor: G=1, L=1, D/B=0
-.macro SEG_ASM64 type base lim
-    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
-    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
-    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
-.endm
+# 64-bit segment descriptor helper provided by asm.h
 
 .code16
 .globl start
@@ -103,10 +98,10 @@ gdtdesc64:
 # Minimal identity-mapped page tables
 .p2align 12
 pml4:
-    .quad pdpt | 0x3
+    .quad pdpt + 0x3
 .p2align 12
 pdpt:
-    .quad pd | 0x3
+    .quad pd + 0x3
 .p2align 12
 pd:
-    .quad 0x00000000 | 0x83  # 2MB page
+    .quad 0x00000000 + 0x83  # 2MB page

--- a/arch/x64/entry64.S
+++ b/arch/x64/entry64.S
@@ -3,12 +3,7 @@
 #include "mmu.h"
 #include "param.h"
 
-# Build a 64-bit segment descriptor
-.macro SEG_ASM64 type base lim
-    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
-    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
-    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
-.endm
+# 64-bit segment descriptor helper provided by asm.h
 
 .p2align 2
 .globl _start

--- a/arch/x64/entryother64.S
+++ b/arch/x64/entryother64.S
@@ -5,12 +5,7 @@
 
 #define CR4_PAE 0x00000020
 
-# Build a 64-bit segment descriptor
-.macro SEG_ASM64 type base lim
-    .word (((\lim) >> 12) & 0xffff), ((\base) & 0xffff)
-    .byte (((\base) >> 16) & 0xff), (0x90 | (\type))
-    .byte (0xA0 | (((\lim) >> 28) & 0xf)), (((\base) >> 24) & 0xff)
-.endm
+# 64-bit segment descriptor helper provided by asm.h
 
 .code16
 .globl start
@@ -94,10 +89,10 @@ gdtdesc64:
 
 .p2align 12
 pml4:
-    .quad pdpt | 0x3
+    .quad pdpt + 0x3
 .p2align 12
 pdpt:
-    .quad pd | 0x3
+    .quad pd + 0x3
 .p2align 12
 pd:
-    .quad 0x00000000 | 0x83
+    .quad 0x00000000 + 0x83

--- a/asm.h
+++ b/asm.h
@@ -18,3 +18,9 @@
 #define STA_X     0x8       // Executable segment
 #define STA_W     0x2       // Writeable (non-executable segments)
 #define STA_R     0x2       // Readable (executable segments)
+
+// 64-bit segment descriptor. G=1, L=1, D/B=0.
+#define SEG_ASM64(type, base, lim)                                \
+        .word (((lim) >> 12) & 0xffff), ((base) & 0xffff);      \
+        .byte (((base) >> 16) & 0xff), (0x90 | (type));         \
+        .byte (0xA0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)

--- a/exec.c
+++ b/exec.c
@@ -53,7 +53,7 @@ exec(char *path, char **argv)
       goto bad;
     if(ph.vaddr % PGSIZE != 0)
       goto bad;
-    if(loaduvm(pgdir, (char*)ph.vaddr, ip, ph.off, ph.filesz) < 0)
+    if(loaduvm(pgdir, (char*)(uintptr_t)ph.vaddr, ip, ph.off, ph.filesz) < 0)
       goto bad;
   }
   iunlockput(ip);
@@ -65,7 +65,7 @@ exec(char *path, char **argv)
   sz = PGROUNDUP(sz);
   if((sz = allocuvm(pgdir, sz, sz + 2*PGSIZE)) == 0)
     goto bad;
-  clearpteu(pgdir, (char*)(sz - 2*PGSIZE));
+  clearpteu(pgdir, (char*)(uintptr_t)(sz - 2*PGSIZE));
   sp = sz;
 
   // Push argument strings, prepare rest of stack in ustack.

--- a/exo.c
+++ b/exo.c
@@ -47,11 +47,9 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 }
 
 
-int __attribute__((weak)) exo_write_disk(exo_blockcap cap, const void *src,
-                                         uint64_t off, uint64_t n) {
 int __attribute__((weak))
-
-exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
+exo_write_disk(struct exo_blockcap cap, const void *src,
+               uint64_t off, uint64_t n)
 {
 
   (void)cap;
@@ -61,7 +59,7 @@ exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t 
   return -1;
 }
 
-int
+int __attribute__((weak))
 exo_send(exo_cap dest, const void *buf, uint64_t len)
 {
   (void)dest;
@@ -70,7 +68,7 @@ exo_send(exo_cap dest, const void *buf, uint64_t len)
   return -1;
 }
 
-int
+int __attribute__((weak))
 exo_recv(exo_cap src, void *buf, uint64_t len)
 {
   (void)src;

--- a/file.h
+++ b/file.h
@@ -26,8 +26,10 @@ struct inode {
   size_t size;
   uint addrs[NDIRECT+1];
 };
-// Must match on-disk inode layout; inode is expected to be 144 bytes
+// Must match on-disk inode layout when compiled for 32-bit targets.
+#ifndef __x86_64__
 _Static_assert(sizeof(struct inode) == 144, "struct inode size incorrect");
+#endif
 
 // table mapping major device number to
 // device functions

--- a/main.c
+++ b/main.c
@@ -62,7 +62,7 @@ mpmain(void)
 }
 
 #ifdef __x86_64__
-pml4e_t entrypgdir[];  // For entry.S
+// 64-bit boot code does not use a statically allocated entry page table.
 #else
 pde_t entrypgdir[];  // For entry.S
 #endif
@@ -86,7 +86,8 @@ startothers(void)
   code = P2V(0x7000);
 #ifdef __x86_64__
 
-  memmove(code, _binary_entryother64_start, (uint)_binary_entryother64_size);
+  memmove(code, _binary_entryother64_start,
+          (size_t)_binary_entryother64_size);
 
 #else
   memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
@@ -124,17 +125,15 @@ startothers(void)
 // hence the __aligned__ attribute.
 // PTE_PS in a page directory entry enables 4Mbyte pages.
 
+#ifndef __x86_64__
 __attribute__((__aligned__(PGSIZE)))
-#ifdef __x86_64__
-pml4e_t entrypgdir[NPDENTRIES] = {
-#else
 pde_t entrypgdir[NPDENTRIES] = {
-#endif
   // Map VA's [0, 4MB) to PA's [0, 4MB)
   [0] = (0) | PTE_P | PTE_W | PTE_PS,
   // Map VA's [KERNBASE, KERNBASE+4MB) to PA's [0, 4MB)
   [KERNBASE>>PDXSHIFT] = (0) | PTE_P | PTE_W | PTE_PS,
 };
+#endif
 
 //PAGEBREAK!
 // Blank page.

--- a/memlayout.h
+++ b/memlayout.h
@@ -30,7 +30,7 @@
 
 #ifdef __x86_64__
 #define V2P(a) (((uint64)(a)) - KERNBASE)
-#define P2V(a) ((void *)(((char *)(a)) + KERNBASE))
+#define P2V(a) ((void *)((uint64)(a) + KERNBASE))
 #else
 #define V2P(a) (((uint)(a)) - KERNBASE)
 #define P2V(a) ((void *)(((char *)(a)) + KERNBASE))

--- a/proc.c
+++ b/proc.c
@@ -137,7 +137,8 @@ userinit(void)
   initproc = p;
   if((p->pgdir = setupkvm()) == 0)
     panic("userinit: out of memory?");
-  inituvm(p->pgdir, _binary_initcode_start, (int)_binary_initcode_size);
+  inituvm(p->pgdir, _binary_initcode_start,
+          (size_t)_binary_initcode_size);
   p->sz = PGSIZE;
   memset(p->tf, 0, sizeof(*p->tf));
   p->tf->cs = (SEG_UCODE << 3) | DPL_USER;

--- a/string.c
+++ b/string.c
@@ -4,7 +4,7 @@
 void*
 memset(void *dst, int c, size_t n)
 {
-  if ((int)dst%4 == 0 && n%4 == 0){
+  if ((uintptr_t)dst%4 == 0 && n%4 == 0){
     c &= 0xFF;
     stosl(dst, (c<<24)|(c<<16)|(c<<8)|c, n/4);
   } else

--- a/x86.h
+++ b/x86.h
@@ -81,11 +81,19 @@ static inline void lidt(struct gatedesc *p, int size) {
 
 static inline void ltr(ushort sel) { asm volatile("ltr %0" : : "r"(sel)); }
 
+#ifdef __x86_64__
+static inline uint readeflags(void) {
+  uint64 eflags;
+  asm volatile("pushfq; popq %0" : "=r"(eflags));
+  return (uint)eflags;
+}
+#else
 static inline uint readeflags(void) {
   uint eflags;
   asm volatile("pushfl; popl %0" : "=r"(eflags));
   return eflags;
 }
+#endif
 
 static inline void loadgs(ushort v) {
   asm volatile("movw %0, %%gs" : : "r"(v));


### PR DESCRIPTION
## Summary
- add a macro for 64-bit segments
- tweak memory address macros for x86_64
- guard inode size assertion on x86_64
- fix casts in exec.c and proc.c
- mark exo stub helpers as weak
- skip bootblock signing when ARCH=x86_64

## Testing
- `make`