### PR TITLE
Add fast IPC syscall

### DIFF
--- a/ipc.h
+++ b/ipc.h
@@ -4,6 +4,14 @@
 
 // zero-copy micro-IPC interface
 // ISA: x86-64; syscall number 0x30 == ipc_fast
+//
+// Calling convention:
+//   rdi - capability badge
+//   rsi - w0
+//   rdx - w1
+//   rcx - w2
+//   r8  - w3
+// On return from the syscall, rsi..r8 contain the reply words.
 
 typedef struct {
   uint64_t badge; // capability badge

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -158,6 +158,7 @@ extern int sys_exo_read_disk(void);
 extern int sys_exo_write_disk(void);
 extern int sys_exo_send(void);
 extern int sys_exo_recv(void);
+extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -192,6 +193,7 @@ static int (*syscalls[])(void) = {
     [SYS_exo_write_disk] sys_exo_write_disk,
     [SYS_exo_send] sys_exo_send,
     [SYS_exo_recv] sys_exo_recv,
+    [SYS_ipc_fast] sys_ipc_fast,
 };
 
 void syscall(void) {

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -196,3 +196,24 @@ int sys_exo_recv(void) {
     return -1;
   return exo_recv(cap, dst, n);
 }
+
+int sys_ipc_fast(void) {
+#ifdef __x86_64__
+  struct trapframe *tf = myproc()->tf;
+  uint64_t badge = tf->rdi;
+  uint64_t w0 = tf->rsi;
+  uint64_t w1 = tf->rdx;
+  uint64_t w2 = tf->rcx;
+  uint64_t w3 = tf->r8;
+
+  (void)badge; // placeholder for future access control
+
+  tf->rsi = w0;
+  tf->rdx = w1;
+  tf->rcx = w2;
+  tf->r8 = w3;
+  return 0;
+#else
+  return -1;
+#endif
+}

--- a/syscall.h
+++ b/syscall.h
@@ -33,4 +33,5 @@
 #define SYS_exo_write_disk 30
 #define SYS_exo_send 31
 #define SYS_exo_recv 32
+#define SYS_ipc_fast 0x30
 


### PR DESCRIPTION
## Summary
- add `SYS_ipc_fast` constant
- implement `sys_ipc_fast` for zero-copy IPC
- register handler in system call table
- document calling convention in `ipc.h`

## Testing
- `make -j4` *(fails: `mmu.h` missing in trapasm.S)*