### PR TITLE
Add basic fast IPC keyboard service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ OBJS = \
        $(KERNEL_DIR)/exo.o\
        $(KERNEL_DIR)/exo/exo_ipc.o\
        $(KERNEL_DIR)/exo_stream.o\
+       $(KERNEL_DIR)/fastipc.o\
         $(KERNEL_DIR)/kernel/exo_cpu.o\
         $(KERNEL_DIR)/kernel/exo_disk.o\
         $(KERNEL_DIR)/kernel/exo_ipc.o\
@@ -244,6 +245,8 @@ UPROGS=\
         _phi\
         _exo_stream_demo\
         _ipc_test\
+        _kbdserv\
+        _rcrs\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/defs.h
+++ b/defs.h
@@ -246,6 +246,8 @@ void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
 void            exo_stream_register(struct exo_stream *);
 void            exo_stream_halt(void);
 void            exo_stream_yield(void);
+void            fastipc_send(zipc_msg_t *);
+int             sys_ipc_fast(void);
 
 
 // number of elements in fixed-size array

--- a/fastipc.h
+++ b/fastipc.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "ipc.h"
+
+// simple kernel-to-user message queue used by ipc_fast
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void fastipc_send(zipc_msg_t *m);
+int sys_ipc_fast(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-kernel/console.c
+++ b/src-kernel/console.c
@@ -14,6 +14,7 @@
 #include "mmu.h"
 #include "proc.h"
 #include "x86.h"
+#include "fastipc.h"
 
 static void consputc(int);
 
@@ -218,6 +219,12 @@ consoleintr(int (*getc)(void))
         c = (c == '\r') ? '\n' : c;
         input.buf[input.e++ % INPUT_BUF] = c;
         consputc(c);
+        {
+          zipc_msg_t m = {0};
+          m.badge = 1;
+          m.w0 = c;
+          fastipc_send(&m);
+        }
         if(c == '\n' || c == C('D') || input.e == input.r+INPUT_BUF){
           input.w = input.e;
           wakeup(&input.r);

--- a/src-kernel/fastipc.c
+++ b/src-kernel/fastipc.c
@@ -1,0 +1,59 @@
+#include "types.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "defs.h"
+#include "fastipc.h"
+
+#define FASTIPC_BUFSZ 64
+
+static struct {
+    struct spinlock lock;
+    zipc_msg_t buf[FASTIPC_BUFSZ];
+    uint r, w;
+    int inited;
+} fastipc;
+
+static void
+fastipc_init(void)
+{
+    if(!fastipc.inited){
+        initlock(&fastipc.lock, "fastipc");
+        fastipc.r = fastipc.w = 0;
+        fastipc.inited = 1;
+    }
+}
+
+void
+fastipc_send(zipc_msg_t *m)
+{
+    fastipc_init();
+    acquire(&fastipc.lock);
+    if(fastipc.w - fastipc.r < FASTIPC_BUFSZ){
+        fastipc.buf[fastipc.w % FASTIPC_BUFSZ] = *m;
+        fastipc.w++;
+    }
+    release(&fastipc.lock);
+}
+
+int
+sys_ipc_fast(void)
+{
+#ifdef __x86_64__
+    struct proc *p = myproc();
+    fastipc_init();
+    acquire(&fastipc.lock);
+    if(fastipc.r == fastipc.w){
+        p->tf->rsi = (uint64)-1;
+        p->tf->rdx = p->tf->rcx = p->tf->r8 = 0;
+    } else {
+        zipc_msg_t m = fastipc.buf[fastipc.r % FASTIPC_BUFSZ];
+        fastipc.r++;
+        p->tf->rsi = m.w0;
+        p->tf->rdx = m.w1;
+        p->tf->rcx = m.w2;
+        p->tf->r8 = m.w3;
+    }
+    release(&fastipc.lock);
+#endif
+    return 0;
+}

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -158,6 +158,7 @@ extern int sys_exo_read_disk(void);
 extern int sys_exo_write_disk(void);
 extern int sys_exo_send(void);
 extern int sys_exo_recv(void);
+extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -202,6 +203,10 @@ void syscall(void) {
 #else
   num = curproc->tf->rax;
 #endif
+  if(num == 0x30){
+    curproc->tf->rax = sys_ipc_fast();
+    return;
+  }
   if (num > 0 && num < NELEM(syscalls) && syscalls[num]) {
 #ifndef __x86_64__
     curproc->tf->eax = syscalls[num]();

--- a/src-uland/init.c
+++ b/src-uland/init.c
@@ -19,6 +19,13 @@ main(void)
   dup(0);  // stdout
   dup(0);  // stderr
 
+  if(fork() == 0){
+    char *kv[] = {"rcrs", 0};
+    exec("rcrs", kv);
+    printf(1, "init: exec rcrs failed\n");
+    exit();
+  }
+
   for(;;){
     printf(1, "init: starting sh\n");
     pid = fork();

--- a/src-uland/kbdserv.c
+++ b/src-uland/kbdserv.c
@@ -1,0 +1,23 @@
+#include "types.h"
+#include "user.h"
+#include "ipc.h"
+#include "fcntl.h"
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    int fd = open("console", O_WRONLY);
+    if(fd < 0)
+        fd = 1;
+    zipc_msg_t m;
+    for(;;){
+        m.badge = 1;
+        zipc_call(&m);
+        if((int64)m.w0 >= 0){
+            char c = m.w0;
+            write(fd, &c, 1);
+        }
+    }
+    return 0;
+}

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -1,0 +1,17 @@
+#include "types.h"
+#include "user.h"
+
+int
+main(void)
+{
+    char *argv[] = {"kbdserv", 0};
+    for(;;){
+        int pid = fork();
+        if(pid == 0){
+            exec("kbdserv", argv);
+            exit();
+        }
+        wait();
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a simple `ipc_fast` ring buffer and handler
- forward console input characters to this ring
- provide a `kbdserv` user program that reads from `ipc_fast`
- launch `kbdserv` via a small reincarnation server from `init`
- hook everything up in the build system

## Testing
- `make -n`