### PR TITLE
Complete exo kernel subsystems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,10 @@ OBJS = \
         $(KERNEL_DIR)/vectors.o\
         $(KERNEL_DIR)/vm.o\
        $(KERNEL_DIR)/exo.o\
+       $(KERNEL_DIR)/exo/exo_cpu.o\
+       $(KERNEL_DIR)/exo/exo_disk.o\
        $(KERNEL_DIR)/exo/exo_ipc.o\
        $(KERNEL_DIR)/exo_stream.o\
-        $(KERNEL_DIR)/kernel/exo_cpu.o\
-        $(KERNEL_DIR)/kernel/exo_disk.o\
-        $(KERNEL_DIR)/kernel/exo_ipc.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o
@@ -122,7 +121,7 @@ endif
 
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -I$(KERNEL_DIR) -I$(ULAND_DIR)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
-ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide
+ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide -I. -I$(KERNEL_DIR) -I$(ULAND_DIR)
 
 # Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)

--- a/src-kernel/exo/exo_cpu.c
+++ b/src-kernel/exo/exo_cpu.c
@@ -1,11 +1,15 @@
 #include "kernel/exo_cpu.h"
 #include "defs.h"
+#include "mmu.h"
+#include "proc.h"
+#include "memlayout.h"
 
-int __attribute__((weak)) exo_yield_to(exo_cap target) {
-  // TODO: implement context switch to the capability
-  (void)target;
-  return -1;
-    // TODO: implement context switch to the capability
-    (void)target;
+int exo_yield_to(exo_cap target)
+{
+  if(target.pa == 0)
     return -1;
+
+  context_t *newctx = (context_t*)P2V(target.pa);
+  swtch(&myproc()->context, newctx);
+  return 0;
 }

--- a/src-kernel/exo/exo_disk.c
+++ b/src-kernel/exo/exo_disk.c
@@ -1,22 +1,53 @@
 #include "kernel/exo_disk.h"
 #include "defs.h"
+#include "fs.h"
+#include "sleeplock.h"
+#include "buf.h"
 
-(void)n;
-  return -1;
-=======
-int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n) {
-int __attribute__((weak)) exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n) {
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
 
-    // TODO: implement disk read via capability
-    (void)cap; (void)dst; (void)off; (void)n;
-    return -1;
+int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
+{
+  struct buf b;
+  uint64_t tot = 0;
+  memset(&b, 0, sizeof(b));
+  initsleeplock(&b.lock, "exodisk");
+
+  while (tot < n) {
+    uint64_t cur = off + tot;
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
+
+    acquiresleep(&b.lock);
+    exo_bind_block(&blk, &b, 0);
+    memmove((char *)dst + tot, b.data + cur % BSIZE, m);
+    releasesleep(&b.lock);
+
+    tot += m;
+  }
+
+  return (int)tot;
 }
 
+int exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
+{
+  struct buf b;
+  uint64_t tot = 0;
+  memset(&b, 0, sizeof(b));
+  initsleeplock(&b.lock, "exodisk");
 
-int __attribute__((weak)) exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n) {
+  while (tot < n) {
+    uint64_t cur = off + tot;
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
-    // TODO: implement disk write via capability
-    (void)cap; (void)src; (void)off; (void)n;
-    return -1;
+    acquiresleep(&b.lock);
+    memmove(b.data + cur % BSIZE, (char *)src + tot, m);
+    exo_bind_block(&blk, &b, 1);
+    releasesleep(&b.lock);
 
+    tot += m;
+  }
+
+  return (int)tot;
 }

--- a/src-kernel/exo/exo_ipc.c
+++ b/src-kernel/exo/exo_ipc.c
@@ -1,14 +1,61 @@
 #include "defs.h"
+#include "spinlock.h"
+#include "proc.h"
 #include "kernel/exo_ipc.h"
 
-int __attribute__((weak)) exo_send(exo_cap dest, const void *buf, uint64_t len) {
-    // TODO: implement IPC send
-    (void)dest; (void)buf; (void)len;
-    return -1;
+#define IPC_BUFSZ 128
+
+struct ipc_state {
+  struct spinlock lock;
+  char buf[IPC_BUFSZ];
+  size_t r;
+  size_t w;
+  int inited;
+};
+
+static struct ipc_state ipcs;
+
+static void ipc_init(void)
+{
+  if(!ipcs.inited){
+    initlock(&ipcs.lock, "exoipc");
+    ipcs.r = ipcs.w = 0;
+    ipcs.inited = 1;
+  }
 }
 
-int __attribute__((weak)) exo_recv(exo_cap src, void *buf, uint64_t len) {
-    // TODO: implement IPC receive
-    (void)src; (void)buf; (void)len;
-    return -1;
+int exo_send(exo_cap dest, const void *buf, uint64_t len)
+{
+  (void)dest;
+  ipc_init();
+  acquire(&ipcs.lock);
+  for(size_t i = 0; i < len; i++){
+    while(ipcs.w - ipcs.r == IPC_BUFSZ){
+      wakeup(&ipcs.r);
+      sleep(&ipcs.w, &ipcs.lock);
+    }
+    ipcs.buf[ipcs.w % IPC_BUFSZ] = ((const char*)buf)[i];
+    ipcs.w++;
+  }
+  wakeup(&ipcs.r);
+  release(&ipcs.lock);
+  return (int)len;
+}
+
+int exo_recv(exo_cap src, void *buf, uint64_t len)
+{
+  (void)src;
+  ipc_init();
+  acquire(&ipcs.lock);
+  for(size_t i = 0; i < len; i++){
+    while(ipcs.r == ipcs.w){
+      wakeup(&ipcs.w);
+      sleep(&ipcs.r, &ipcs.lock);
+    }
+    ((char*)buf)[i] = ipcs.buf[ipcs.r % IPC_BUFSZ];
+    ipcs.r++;
+  }
+  wakeup(&ipcs.w);
+  release(&ipcs.lock);
+  return (int)len;
 }


### PR DESCRIPTION
## Summary
- implement missing exo_* routines in kernel `src-kernel/exo`
- enable disk capability I/O
- add real context switch via exo_yield_to
- provide IPC with exo_send/exo_recv
- compile kernel using the exo subsystem sources

## Testing
- `make`
