### PR TITLE
Optimize pctr capability lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS = \
        $(KERNEL_DIR)/exo/exo_cpu.o\
        $(KERNEL_DIR)/exo/exo_disk.o\
        $(KERNEL_DIR)/exo/exo_ipc.o\
-       $(KERNEL_DIR)/exo_stream.o\=======
+       $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/fastipc.o\
         $(KERNEL_DIR)/kernel/exo_cpu.o\
         $(KERNEL_DIR)/kernel/exo_disk.o\

--- a/defs.h
+++ b/defs.h
@@ -40,6 +40,7 @@ extern struct ptable ptable;
 #include "kernel/exo_disk.h"
 #include "kernel/exo_ipc.h"
 #include "kernel/exo_mem.h"
+#include "fastipc.h"
 
 // bio.c
 void binit(void);
@@ -154,6 +155,7 @@ void            userinit(void);
 int             wait(void);
 void            wakeup(void*);
 void            yield(void);
+struct proc*    pctr_lookup(uint);
 
 
 

--- a/src-kernel/exo.c
+++ b/src-kernel/exo.c
@@ -13,12 +13,9 @@ void exo_pctr_transfer(struct trapframe *tf) {
   struct proc *p;
 
   acquire(&ptable.lock);
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-    if (p->state != UNUSED && p->pctr_cap == cap) {
-      p->pctr_signal++;
-      break;
-    }
-  }
+  p = pctr_lookup(cap);
+  if (p && p->state != UNUSED)
+    p->pctr_signal++;
   release(&ptable.lock);
 }
 


### PR DESCRIPTION
## Summary
- add a hash table mapping `pctr_cap` to `struct proc`
- register and unregister processes from this table
- use constant-time lookup in `exo_pctr_transfer`
- fix Makefile artifact and include `fastipc.h`

## Testing
- `make` *(fails: struct trapframe has no member named 'rax')*