### PR TITLE
Add typed channel interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS = \
        $(KERNEL_DIR)/exo/exo_cpu.o\
        $(KERNEL_DIR)/exo/exo_disk.o\
        $(KERNEL_DIR)/exo/exo_ipc.o\
-       $(KERNEL_DIR)/exo_stream.o\=======
+       $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/fastipc.o\
         $(KERNEL_DIR)/kernel/exo_cpu.o\
         $(KERNEL_DIR)/kernel/exo_disk.o\
@@ -203,6 +203,7 @@ ULIB = \
         $(ULAND_DIR)/umalloc.o \
         $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
+        $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o
 
 _%: $(ULAND_DIR)/%.o $(ULIB)

--- a/caplib.h
+++ b/caplib.h
@@ -8,9 +8,7 @@ int cap_alloc_block(uint dev, exo_blockcap *cap);
 int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_set_timer(void (*handler)(void));
 void cap_yield_to(context_t **old, context_t *target);
-int cap_yield_to_cap(exo_cap target);p
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int cap_yield_to_cap(exo_cap target);
 int cap_send(exo_cap dest, const void *buf, uint64 len);
 int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);

--- a/chan.h
+++ b/chan.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "types.h"
+#include "caplib.h"
+
+// Generic channel descriptor storing expected message size
+typedef struct chan {
+    size_t msg_size;
+} chan_t;
+
+// Allocate a channel expecting messages of size msg_size bytes
+chan_t *chan_create(size_t msg_size);
+
+// Free a channel allocated with chan_create
+void chan_destroy(chan_t *c);
+
+// Send and receive through an exo capability endpoint
+int endpoint_send(chan_t *c, exo_cap dest, const void *msg);
+int endpoint_recv(chan_t *c, exo_cap src, void *msg);
+
+// Helper macro to declare a typed channel wrapper
+// Usage: CHAN_DECLARE(mychan, struct mymsg);
+// Provides mychan_t type with create/send/recv functions
+#define CHAN_DECLARE(name, type)                                    \
+    typedef struct {                                                \
+        chan_t base;                                                \
+    } name##_t;                                                     \
+    static inline name##_t *name##_create(void) {                   \
+        return (name##_t *)chan_create(sizeof(type));               \
+    }                                                               \
+    static inline void name##_destroy(name##_t *c) {                 \
+        chan_destroy(&c->base);                                     \
+    }                                                               \
+    static inline int name##_send(name##_t *c, exo_cap dest, const type *m){ \
+        if(c->base.msg_size != sizeof(type)) return -1;             \
+        return endpoint_send(&c->base, dest, m);                    \
+    }                                                               \
+    static inline int name##_recv(name##_t *c, exo_cap src, type *m){ \
+        if(c->base.msg_size != sizeof(type)) return -1;             \
+        return endpoint_recv(&c->base, src, m);                     \
+    }
+

--- a/defs.h
+++ b/defs.h
@@ -39,6 +39,7 @@ extern struct ptable ptable;
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
 #include "kernel/exo_ipc.h"
+#include "ipc.h"
 #include "kernel/exo_mem.h"
 
 // bio.c

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -205,7 +205,11 @@ void syscall(void) {
   num = curproc->tf->rax;
 #endif
   if(num == 0x30){
+#ifdef __x86_64__
     curproc->tf->rax = sys_ipc_fast();
+#else
+    curproc->tf->eax = sys_ipc_fast();
+#endif
     return;
   }
   if (num > 0 && num < NELEM(syscalls) && syscalls[num]) {

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -1,0 +1,30 @@
+#include "chan.h"
+#include "user.h"
+
+chan_t *
+chan_create(size_t msg_size)
+{
+    chan_t *c = malloc(sizeof(chan_t));
+    if(c)
+        c->msg_size = msg_size;
+    return c;
+}
+
+void
+chan_destroy(chan_t *c)
+{
+    free(c);
+}
+
+int
+endpoint_send(chan_t *c, exo_cap dest, const void *msg)
+{
+    return cap_send(dest, msg, c->msg_size);
+}
+
+int
+endpoint_recv(chan_t *c, exo_cap src, void *msg)
+{
+    return cap_recv(src, msg, c->msg_size);
+}
+

--- a/user.h
+++ b/user.h
@@ -38,8 +38,6 @@ int exo_unbind_page(exo_cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_yield_to(exo_cap target);
-int exo_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int exo_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
 int exo_send(exo_cap dest, const void *buf, uint64 len);
 int exo_recv(exo_cap src, void *buf, uint64 len);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);


### PR DESCRIPTION
## Summary
- implement generic channel API for typed messages
- provide macros to declare typed channels
- connect channel send/recv to capability-based IPC
- clean up capability headers and user syscall prototypes
- fix syscall rax/eax selection for fast IPC

## Testing
- `make src-uland/chan.o`