### PR TITLE
Fix builtins execution in shell

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -2,6 +2,7 @@ formatting:
 	need to fix PAGEBREAK mechanism
 
 sh:
-	can't always runcmd in child -- breaks cd.
-	maybe should hard-code PATH=/ ?
+       built-ins (e.g. cd) now run correctly within lists, pipes, and
+       background commands.
+       maybe should hard-code PATH=/ ?
 

--- a/README
+++ b/README
@@ -6,6 +6,10 @@ xv6 is a re-implementation of Dennis Ritchie's and Ken Thompson's Unix
 Version 6 (v6).  xv6 loosely follows the structure and style of v6,
 but is implemented for a modern x86-based multiprocessor using ANSI C.
 
+The user-level shell supports built-in commands such as ``cd``.  These
+built-ins execute directly in the shell process even when used in command
+lists, pipelines, or background jobs.
+
 ACKNOWLEDGMENTS
 
 xv6 is inspired by John Lions's Commentary on UNIX 6th Edition (Peer

--- a/src-uland/sh.c
+++ b/src-uland/sh.c
@@ -81,14 +81,16 @@ runcmd(struct cmd *cmd)
     panic("runcmd");
 
   case EXEC:
-    ecmd = (struct execcmd*)cmd;
-    if(ecmd->argv[0] == 0)
+    ecmd = (struct execcmd *)cmd;
+    if (ecmd->argv[0] == 0)
       exit();
+    if (runbuiltin(cmd))
+      break;
     exec(ecmd->argv[0], ecmd->argv);
-    if(ecmd->argv[0][0] != '/'){
+    if (ecmd->argv[0][0] != '/') {
       char path[512];
       strcpy(path, "/");
-      strcpy(path+1, ecmd->argv[0]);
+      strcpy(path + 1, ecmd->argv[0]);
       exec(path, ecmd->argv);
     }
     printf(2, "exec %s failed\n", ecmd->argv[0]);
@@ -201,6 +203,19 @@ fork1(void)
   if(pid == -1)
     panic("fork");
   return pid;
+}
+
+static int isbuiltin(struct cmd *cmd) {
+  struct execcmd *ecmd;
+
+  if (cmd->type != EXEC)
+    return 0;
+
+  ecmd = (struct execcmd *)cmd;
+  if (ecmd->argv[0] == 0)
+    return 0;
+
+  return strcmp(ecmd->argv[0], "cd") == 0;
 }
 
 int


### PR DESCRIPTION
## Summary
- allow `EXEC` nodes to run built-ins before attempting `exec`
- document new builtin handling in BUGS and README

## Testing
- `make -j2` *(fails: missing separator in Makefile)*