### PR TITLE
Clean up disk capability prototypes

### DIFF
--- a/caplib.h
+++ b/caplib.h
@@ -8,9 +8,7 @@ int cap_alloc_block(uint dev, exo_blockcap *cap);
 int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_set_timer(void (*handler)(void));
 void cap_yield_to(context_t **old, context_t *target);
-int cap_yield_to_cap(exo_cap target);p
-int cap_read_disk(exo_cap cap, void *dst, uint64 off, uint64 n);
-int cap_write_disk(exo_cap cap, const void *src, uint64 off, uint64 n);
+int cap_yield_to_cap(exo_cap target);
 int cap_send(exo_cap dest, const void *buf, uint64 len);
 int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);


### PR DESCRIPTION
## Summary
- remove stray `p` typo from `cap_yield_to_cap` prototype
- drop unused `exo_cap` overloads of `cap_read_disk`/`cap_write_disk`

## Testing
- `make` *(fails: missing separator)*