### PR TITLE
Integrate exo scheduler hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS = \
        $(KERNEL_DIR)/exo/exo_cpu.o\
        $(KERNEL_DIR)/exo/exo_disk.o\
        $(KERNEL_DIR)/exo/exo_ipc.o\
-       $(KERNEL_DIR)/exo_stream.o\=======
+       $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/fastipc.o\
         $(KERNEL_DIR)/kernel/exo_cpu.o\
         $(KERNEL_DIR)/kernel/exo_disk.o\

--- a/README
+++ b/README
@@ -103,7 +103,11 @@ EXO STREAMS
 ``struct exo_stream`` links scheduler modules together.  Register a stream
 with ``exo_stream_register`` and call ``exo_stream_yield`` or
 ``exo_stream_halt`` to invoke the registered callbacks.  See the
-``EXO_STREAM`` design note for details.
+``EXO_STREAM`` design note for details.  ``yield()`` invokes
+``exo_stream_yield`` before scheduling another process.  When the
+scheduler has no runnable tasks it calls ``exo_stream_halt`` rather
+than spinning; the default implementation issues ``hlt`` if no stream
+is registered.
 
 
 USER DEMO: EXO_YIELD_TO AND STREAMS
@@ -114,4 +118,3 @@ placeholder STREAMS ``stop`` and ``yield`` calls.  Build the system as
 usual with ``make``; the resulting ``fs.img`` will contain the new
 ``exo_stream_demo`` binary.  Run it inside QEMU to observe the stub
 functions printing messages that indicate the expected invocation order.
-

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -335,6 +335,7 @@ scheduler(void)
   struct proc *p;
   struct cpu *c = mycpu();
   c->proc = 0;
+  int found;
   
   for(;;){
     // Enable interrupts on this processor.
@@ -342,9 +343,11 @@ scheduler(void)
 
     // Loop over process table looking for process to run.
     acquire(&ptable.lock);
+    found = 0;
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
       if(p->state != RUNNABLE)
         continue;
+      found = 1;
 
       // Switch to chosen process.  It is the process's job
       // to release ptable.lock and then reacquire it
@@ -361,6 +364,8 @@ scheduler(void)
       c->proc = 0;
     }
     release(&ptable.lock);
+    if(!found)
+      exo_stream_halt();
 
   }
 }
@@ -396,6 +401,7 @@ void
 yield(void)
 {
   acquire(&ptable.lock);  //DOC: yieldlock
+  exo_stream_yield();
   myproc()->state = RUNNABLE;
   sched();
   release(&ptable.lock);


### PR DESCRIPTION
## Summary
- invoke `exo_stream_yield()` whenever a process yields
- halt CPU through `exo_stream_halt()` when no tasks are runnable
- document scheduler expectations for the stream interface

## Testing
- `make -s` *(fails: `zipc_msg_t` unknown type)*