### PR TITLE
Fix reviewdog workflow

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y shellcheck
       - name: Run ${{ matrix.linter.id }} & feed Reviewdog
 
-        uses: reviewdog/reviewdog@v0.17.4
+        uses: reviewdog/reviewdog@master
 
         with:
           name: ${{ matrix.linter.id }}
@@ -38,4 +38,8 @@ jobs:
           level: warning
       - name: Emit summary
         if: always()
-        run: reviewdog -reporter=local -format=rdjson -f .rdjson > $RUNNER_TEMP/rd.json
+        uses: reviewdog/reviewdog@master
+        with:
+          reporter: local
+          format: rdjson
+          output: ${{ runner.temp }}/rd.json


### PR DESCRIPTION
## Summary
- fix reviewdog invocation in `lint-and-annotate` workflow to avoid missing command
- update to use master version of reviewdog action

## Testing
- `make` *(fails: No rule to make target 'src-kernel/exo/exo_cpu.o', needed by 'kernel')*
- `git status --short`