### PR TITLE
Move scheduling out of kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,13 @@ OBJS = \
         $(KERNEL_DIR)/uart.o\
         $(KERNEL_DIR)/vectors.o\
         $(KERNEL_DIR)/vm.o\
-       $(KERNEL_DIR)/exo.o\
-       $(KERNEL_DIR)/kernel/exo_cpu.o\
-       $(KERNEL_DIR)/kernel/exo_disk.o\
-       $(KERNEL_DIR)/kernel/exo_ipc.o\
-       $(KERNEL_DIR)/exo_stream.o\
-       $(KERNEL_DIR)/fastipc.o\
-       $(KERNEL_DIR)/exo/exo_cpu.o\
-       $(KERNEL_DIR)/exo/exo_disk.o\
-       $(KERNEL_DIR)/exo/exo_ipc.o\
-       $(KERNEL_DIR)/endpoint.o\
+        $(KERNEL_DIR)/exo.o\
+        $(KERNEL_DIR)/kernel/exo_cpu.o\
+        $(KERNEL_DIR)/kernel/exo_disk.o\
+        $(KERNEL_DIR)/kernel/exo_ipc.o\
+        $(KERNEL_DIR)/exo_stream.o\
+        $(KERNEL_DIR)/fastipc.o\
+        $(KERNEL_DIR)/endpoint.o\
 
 
 
@@ -206,7 +203,8 @@ ULIB = \
         $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
         $(ULAND_DIR)/chan.o \
-        $(ULAND_DIR)/math_core.o
+        $(ULAND_DIR)/math_core.o \
+        $(ULAND_DIR)/libos/sched.o
 
 _%: $(ULAND_DIR)/%.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^

--- a/defs.h
+++ b/defs.h
@@ -161,6 +161,7 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 struct proc*    pctr_lookup(uint);
+struct proc*    allocproc(void);
 
 
 

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -122,7 +122,7 @@ myproc(void) {
 // If found, change state to EMBRYO and initialize
 // state required to run in the kernel.
 // Otherwise return 0.
-static struct proc*
+struct proc*
 allocproc(void)
 {
   struct proc *p;

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -160,6 +160,7 @@ extern int sys_exo_send(void);
 extern int sys_exo_recv(void);
 extern int sys_endpoint_send(void);
 extern int sys_endpoint_recv(void);
+extern int sys_proc_alloc(void);
 extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
@@ -197,6 +198,7 @@ static int (*syscalls[])(void) = {
     [SYS_exo_recv] sys_exo_recv,
     [SYS_endpoint_send] sys_endpoint_send,
     [SYS_endpoint_recv] sys_endpoint_recv,
+    [SYS_proc_alloc] sys_proc_alloc,
     [SYS_ipc_fast] sys_ipc_fast,
 };
 

--- a/src-uland/libos/sched.c
+++ b/src-uland/libos/sched.c
@@ -1,0 +1,29 @@
+#include "libos/sched.h"
+
+#define MAX_PROCS 64
+
+static exo_cap runq[MAX_PROCS];
+static int nprocs = 0;
+static int cur = -1;
+
+void sched_add(exo_cap cap) {
+    if(nprocs < MAX_PROCS)
+        runq[nprocs++] = cap;
+}
+
+static void sched_tick(void) {
+    if(nprocs == 0)
+        return;
+    cur = (cur + 1) % nprocs;
+    cap_yield_to_cap(runq[cur]);
+}
+
+void sched_install_timer(void) {
+    cap_set_timer(sched_tick);
+}
+
+void sched_run(void) {
+    sched_install_timer();
+    while(1)
+        sched_tick();
+}

--- a/src-uland/libos/sched.h
+++ b/src-uland/libos/sched.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "types.h"
+#include "user.h"
+#include "caplib.h"
+
+void sched_add(exo_cap cap);
+void sched_install_timer(void);
+void sched_run(void);

--- a/syscall.h
+++ b/syscall.h
@@ -35,5 +35,6 @@
 #define SYS_exo_recv 32
 #define SYS_endpoint_send 33
 #define SYS_endpoint_recv 34
+#define SYS_proc_alloc 35
 #define SYS_ipc_fast 0x30
 

--- a/user.h
+++ b/user.h
@@ -45,6 +45,7 @@ int endpoint_send(zipc_msg_t *msg);
 int endpoint_recv(zipc_msg_t *msg);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
+exo_cap proc_alloc(void);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/usys.S
+++ b/usys.S
@@ -67,5 +67,6 @@ SYSCALL(exo_send)
 SYSCALL(exo_recv)
 SYSCALL(endpoint_send)
 SYSCALL(endpoint_recv)
+SYSCALL(proc_alloc)
 
 


### PR DESCRIPTION
## Summary
- expose `allocproc` and add new syscall `proc_alloc`
- implement a simple round-robin scheduler in `libos`
- wire new scheduler into build
- fix indentation in Makefile

## Testing
- `make -s`
