### PR TITLE
Implement capability authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ OBJS = \
        $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/fastipc.o\
        $(KERNEL_DIR)/endpoint.o\
+       $(KERNEL_DIR)/cap.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o
@@ -200,15 +201,14 @@ $(KERNEL_DIR)/vectors.S: vectors.pl
 
 LIBOS_OBJS = \
         $(ULAND_DIR)/ulib.o \
-       usys.o \
+        usys.o \
         $(ULAND_DIR)/printf.o \
         $(ULAND_DIR)/umalloc.o \
-       $(KERNEL_DIR)/swtch.o \
+        $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
+        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o
 

--- a/caplib.h
+++ b/caplib.h
@@ -13,4 +13,6 @@ void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
+int cap_send(exo_cap dest, const void *buf, uint64 len);
+int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_ipc_echo_demo(void);

--- a/defs.h
+++ b/defs.h
@@ -249,6 +249,8 @@ int             insert_pte(pde_t*, void*, uint, int);
 #endif
 struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
+struct exo_cap  cap_new(uint id, uint rights, uint owner);
+int             cap_verify(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
 void            exo_flush_block(struct exo_blockcap *, void *);

--- a/exo.h
+++ b/exo.h
@@ -2,8 +2,15 @@
 #define EXO_H
 #include "types.h"
 
+typedef struct hash256 {
+  uint64 parts[4];
+} hash256_t;
+
 typedef struct exo_cap {
-  uint pa;
+  uint id;
+  uint rights;
+  uint owner;
+  hash256_t auth_tag;
 } exo_cap;
 
 typedef struct exo_blockcap {
@@ -13,5 +20,8 @@ typedef struct exo_blockcap {
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
+
+exo_cap cap_new(uint id, uint rights, uint owner);
+int cap_verify(exo_cap c);
 
 #endif // EXO_H

--- a/include/exokernel.h
+++ b/include/exokernel.h
@@ -8,11 +8,11 @@
  * enforces no policy on queue sizes or scheduling.
  */
 
-/* Allocate a physical page and return a capability referencing it.
- * The page is not mapped into the caller's address space.  Returns a
- * capability with pa=0 on failure.
+/* Allocate a physical page and store a capability referencing it in *cap.
+ * The page is not mapped into the caller's address space.  Returns 0 on
+ * success.
  */
-exo_cap exo_alloc_page(void);
+int exo_alloc_page(exo_cap *cap);
 
 /* Free the page referenced by cap and remove any mappings to it. */
 int exo_unbind_page(exo_cap cap);
@@ -32,17 +32,17 @@ int exo_bind_block(exo_blockcap *cap, void *data, int write);
  * must be saved in a user-managed structure.  The kernel does not
  * choose the next runnable task.
  */
-int exo_yield_to(exo_cap target);
+int exo_yield_to(exo_cap *target);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any
  * queuing or flow control is managed in user space.
  */
-int exo_send(exo_cap dest, const void *buf, uint64 len);
+int exo_send(exo_cap *dest, const void *buf, uint64 len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.
  * The call blocks according to policy implemented by the library OS.
  */
-int exo_recv(exo_cap src, void *buf, uint64 len);
+int exo_recv(exo_cap *src, void *buf, uint64 len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
@@ -54,6 +54,7 @@ enum exo_syscall {
     EXO_SYSCALL_UNBIND_PAGE = SYS_exo_unbind_page,
     EXO_SYSCALL_ALLOC_BLOCK = SYS_exo_alloc_block,
     EXO_SYSCALL_BIND_BLOCK  = SYS_exo_bind_block,
+    EXO_SYSCALL_FLUSH_BLOCK = SYS_exo_flush_block,
     EXO_SYSCALL_YIELD_TO    = SYS_exo_yield_to,
     EXO_SYSCALL_SEND        = SYS_exo_send,
     EXO_SYSCALL_RECV        = SYS_exo_recv,

--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -1,0 +1,51 @@
+#include "types.h"
+#include "exo.h"
+#include "defs.h"
+
+static const uint8_t cap_secret[32] = {
+    0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
+    0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
+    0x55,0xaa,0x55,0xaa,0x00,0x11,0x22,0x33,
+    0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
+};
+
+static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
+    const uint64 prime = 1099511628211ULL;
+    uint64 h = seed;
+    for(size_t i=0;i<len;i++) {
+        h ^= data[i];
+        h *= prime;
+    }
+    return h;
+}
+
+static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
+    const uint64 basis = 14695981039346656037ULL;
+    for(int i=0;i<4;i++)
+        out->parts[i] = fnv64(data, len, basis + i);
+}
+
+static void hmac_hash(const void *msg, size_t len, hash256_t *out) {
+    // simple HMAC-like: hash(secret || msg)
+    uint8_t buf[sizeof(cap_secret)+len];
+    memmove(buf, cap_secret, sizeof(cap_secret));
+    memmove(buf+sizeof(cap_secret), msg, len);
+    hash256(buf, sizeof(buf), out);
+}
+
+exo_cap cap_new(uint id, uint rights, uint owner) {
+    exo_cap c;
+    c.id = id;
+    c.rights = rights;
+    c.owner = owner;
+    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    hmac_hash(&tmp, sizeof(tmp), &c.auth_tag);
+    return c;
+}
+
+int cap_verify(exo_cap c) {
+    hash256_t h;
+    struct { uint id; uint rights; uint owner; } tmp = { c.id, c.rights, c.owner };
+    hmac_hash(&tmp, sizeof(tmp), &h);
+    return memcmp(&h, &c.auth_tag, sizeof(hash256_t)) == 0;
+}

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -70,7 +70,7 @@ int exo_recv(exo_cap src, void *buf, uint64_t len) {
   release(&ipcs.lock);
 
   size_t total = sizeof(zipc_msg_t);
-  if (e.frame.pa)
+  if (e.frame.id)
     total += sizeof(exo_cap);
 
   if (len > sizeof(zipc_msg_t))

--- a/src-kernel/kernel/exo_cpu.c
+++ b/src-kernel/kernel/exo_cpu.c
@@ -7,10 +7,10 @@
 
 int exo_yield_to(exo_cap target)
 {
-  if(target.pa == 0)
+  if(target.id == 0)
     return -1;
 
-  context_t *newctx = (context_t*)P2V(target.pa);
+  context_t *newctx = (context_t*)P2V(target.id);
   swtch(&myproc()->context, newctx);
   return 0;
 }

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -93,14 +93,20 @@ int sys_set_timer_upcall(void) {
 
 // allocate a physical page and return its capability
 int sys_exo_alloc_page(void) {
+  exo_cap *ucap;
+  if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
+    return -1;
   exo_cap cap = exo_alloc_page();
-  return cap.pa;
+  memmove(ucap, &cap, sizeof(cap));
+  return 0;
 }
 
 // unbind and free a physical page by capability
 int sys_exo_unbind_page(void) {
   exo_cap cap;
-  if (argint(0, (int *)&cap.pa) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0)
+    return -1;
+  if (!cap_verify(cap))
     return -1;
   return exo_unbind_page(cap);
 }
@@ -161,7 +167,9 @@ int sys_exo_flush_block(void) {
 
 int sys_exo_yield_to(void) {
   exo_cap cap;
-  if (argint(0, (int *)&cap.pa) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0)
+    return -1;
+  if (!cap_verify(cap))
     return -1;
   return exo_yield_to(cap);
 }
@@ -198,9 +206,11 @@ int sys_exo_send(void) {
   exo_cap cap;
   char *src;
   uint n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)
+    return -1;
+  if (!cap_verify(cap))
     return -1;
   return exo_send(cap, src, n);
 }
@@ -209,9 +219,11 @@ int sys_exo_recv(void) {
   exo_cap cap;
   char *dst;
   uint n;
-  if (argint(0, (int *)&cap.pa) < 0 ||
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
+    return -1;
+  if (!cap_verify(cap))
     return -1;
   return exo_recv(cap, dst, n);
 }
@@ -250,8 +262,12 @@ int sys_proc_alloc(void) {
   np->state = RUNNABLE;
   release(&ptable.lock);
 
-  exo_cap cap = { V2P(np->context) };
-  return cap.pa;
+  exo_cap *ucap;
+  if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
+    return -1;
+  exo_cap cap = cap_new(V2P(np->context), 0, curproc->pid);
+  memmove(ucap, &cap, sizeof(cap));
+  return 0;
 }
 
 // Provided by fastipc.c

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -443,9 +443,8 @@ exo_cap
 exo_alloc_page(void)
 {
   char *mem = kalloc();
-  exo_cap cap;
-  cap.pa = mem ? V2P(mem) : 0;
-  return cap;
+  uint id = mem ? V2P(mem) : 0;
+  return cap_new(id, 0, myproc()->pid);
 }
 
 // Remove any mappings to the page referenced by cap and free it.
@@ -456,7 +455,7 @@ exo_unbind_page(exo_cap cap)
   pde_t *pgdir = p->pgdir;
   pte_t *pte;
   uint a;
-  uint pa = cap.pa;
+  uint pa = cap.id;
 
   for(a = 0; a < p->sz; a += PGSIZE){
     if((pte = walkpgdir(pgdir, (void*)a, 0)) != 0 && (*pte & PTE_P)){

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -2,7 +2,11 @@
 #include "types.h"
 #include "user.h"
 
-exo_cap cap_alloc_page(void) { return exo_alloc_page(); }
+exo_cap cap_alloc_page(void) {
+  exo_cap c;
+  exo_alloc_page(&c);
+  return c;
+}
 
 int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
 
@@ -24,7 +28,7 @@ void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);
 }
 
-int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
+int cap_yield_to_cap(exo_cap target) { return exo_yield_to(&target); }
 
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n) {
   return exo_read_disk(cap, dst, off, n);
@@ -35,11 +39,11 @@ int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n) {
 }
 
 int cap_send(exo_cap dest, const void *buf, uint64 len) {
-  return exo_send(dest, buf, len);
+  return exo_send(&dest, buf, len);
 }
 
 int cap_recv(exo_cap src, void *buf, uint64 len) {
-  return exo_recv(src, buf, len);
+  return exo_recv(&src, buf, len);
 }
 
 int cap_ipc_echo_demo(void) {

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -3,8 +3,8 @@
 #include "user.h"
 
 // Stub function since kernel support is unavailable
-int exo_yield_to(exo_cap target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target.pa);
+int exo_yield_to(exo_cap *target) {
+  printf(1, "exo_yield_to called with cap %p\n", (void *)target->id);
   return 0;
 }
 
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   exo_cap cap = {0};
   printf(1, "STREAMS/exo yield demo\n");
   streams_stop();
-  exo_yield_to(cap);
+  exo_yield_to(&cap);
   streams_yield();
   exit();
 }

--- a/syscall.h
+++ b/syscall.h
@@ -28,13 +28,14 @@
 #define SYS_exo_unbind_page 25
 #define SYS_exo_alloc_block 26
 #define SYS_exo_bind_block 27
-#define SYS_exo_yield_to 28
-#define SYS_exo_read_disk 29
-#define SYS_exo_write_disk 30
-#define SYS_exo_send 31
-#define SYS_exo_recv 32
-#define SYS_endpoint_send 33
-#define SYS_endpoint_recv 34
-#define SYS_proc_alloc 35
+#define SYS_exo_flush_block 28
+#define SYS_exo_yield_to 29
+#define SYS_exo_read_disk 30
+#define SYS_exo_write_disk 31
+#define SYS_exo_send 32
+#define SYS_exo_recv 33
+#define SYS_endpoint_send 34
+#define SYS_endpoint_recv 35
+#define SYS_proc_alloc 36
 #define SYS_ipc_fast 0x30
 

--- a/user.h
+++ b/user.h
@@ -34,19 +34,19 @@ int mappte(void *, void *, int);
 int exo_pctr_transfer(int cap);
 
 int set_timer_upcall(void (*handler)(void));
-exo_cap exo_alloc_page(void);
-int exo_unbind_page(exo_cap);
+int exo_alloc_page(exo_cap *cap);
+int exo_unbind_page(exo_cap cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_flush_block(exo_blockcap *cap);
-int exo_yield_to(exo_cap target);
-int exo_send(exo_cap dest, const void *buf, uint64 len);
-int exo_recv(exo_cap src, void *buf, uint64 len);
+int exo_yield_to(exo_cap *target);
+int exo_send(exo_cap *dest, const void *buf, uint64 len);
+int exo_recv(exo_cap *src, void *buf, uint64 len);
 int endpoint_send(zipc_msg_t *msg);
 int endpoint_recv(zipc_msg_t *msg);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
-exo_cap proc_alloc(void);
+int proc_alloc(exo_cap *cap);
 
 // ulib.c
 int stat(const char *, struct stat *);


### PR DESCRIPTION
## Summary
- add 256-bit hash-based capability fields
- implement simple capability HMAC in new `cap.c`
- verify capabilities in syscall handlers
- update user library to use pointer-based capability APIs
- compile new module

## Testing
- `make -s`