### PR TITLE
Add capability ownership tracking

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -4,11 +4,13 @@
 
 typedef struct exo_cap {
   uint pa;
+  uint owner;
 } exo_cap;
 
 typedef struct exo_blockcap {
   uint dev;
   uint blockno;
+  uint owner;
 } exo_blockcap;
 
 exo_cap exo_alloc_page(void);

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -38,7 +38,7 @@ int exo_send(exo_cap dest, const void *buf, uint64_t len) {
   size_t mlen = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
   memmove(&m, buf, mlen);
 
-  exo_cap fr = {0};
+  exo_cap fr = {0, 0};
   if (len > sizeof(zipc_msg_t))
     memmove(&fr, (const char *)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
 

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -82,7 +82,7 @@ balloc(uint dev)
 struct exo_blockcap
 exo_alloc_block(uint dev)
 {
-  struct exo_blockcap cap = {0, 0};
+  struct exo_blockcap cap = {0, 0, 0};
   int b, bi, m;
   struct buf *bp = 0;
 
@@ -97,6 +97,7 @@ exo_alloc_block(uint dev)
         bzero(dev, b + bi);
         cap.dev = dev;
         cap.blockno = b + bi;
+        cap.owner = myproc()->pid;
         return cap;
       }
     }
@@ -110,6 +111,8 @@ exo_alloc_block(uint dev)
 void
 exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
 {
+  if(cap->owner != myproc()->pid)
+    return;
   buf->dev = cap->dev;
   buf->blockno = cap->blockno;
   if (write)
@@ -120,6 +123,8 @@ exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
 void
 exo_flush_block(struct exo_blockcap *cap, void *data)
 {
+  if(cap->owner != myproc()->pid)
+    return;
   struct buf b;
   memset(&b, 0, sizeof(b));
   initsleeplock(&b.lock, "exoflush");

--- a/src-kernel/kernel/exo_disk.c
+++ b/src-kernel/kernel/exo_disk.c
@@ -10,6 +10,8 @@
 int
 exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 {
+  if(cap.owner != myproc()->pid)
+    return -1;
   struct buf b;
   uint64_t tot = 0;
   memset(&b, 0, sizeof(b));
@@ -17,7 +19,7 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE, cap.owner };
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);
@@ -34,6 +36,8 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 int
 exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
 {
+  if(cap.owner != myproc()->pid)
+    return -1;
   struct buf b;
   uint64_t tot = 0;
   memset(&b, 0, sizeof(b));
@@ -41,7 +45,7 @@ exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t 
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE, cap.owner };
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -114,6 +114,7 @@ int sys_exo_alloc_block(void) {
   cap = exo_alloc_block(dev);
   ucap->dev = cap.dev;
   ucap->blockno = cap.blockno;
+  ucap->owner = cap.owner;
   return 0;
 }
 
@@ -250,8 +251,12 @@ int sys_proc_alloc(void) {
   np->state = RUNNABLE;
   release(&ptable.lock);
 
-  exo_cap cap = { V2P(np->context) };
+  exo_cap cap = { V2P(np->context), np->pid };
+#ifdef __x86_64__
+  return *(uint64_t *)&cap;
+#else
   return cap.pa;
+#endif
 }
 
 // Provided by fastipc.c

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -445,6 +445,7 @@ exo_alloc_page(void)
   char *mem = kalloc();
   exo_cap cap;
   cap.pa = mem ? V2P(mem) : 0;
+  cap.owner = myproc()->pid;
   return cap;
 }
 
@@ -453,6 +454,8 @@ int
 exo_unbind_page(exo_cap cap)
 {
   struct proc *p = myproc();
+  if(cap.owner != p->pid)
+    return -1;
   pde_t *pgdir = p->pgdir;
   pte_t *pte;
   uint a;

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -45,7 +45,7 @@ int cap_recv(exo_cap src, void *buf, uint64 len) {
 int cap_ipc_echo_demo(void) {
   const char *msg = "ping";
   char buf[5];
-  exo_cap cap = {0};
+  exo_cap cap = {0, 0};
   cap_send(cap, msg, 4);
   cap_recv(cap, buf, 4);
   buf[4] = '\0';

--- a/src-uland/ipc_test.c
+++ b/src-uland/ipc_test.c
@@ -8,7 +8,7 @@ main(int argc, char *argv[])
   (void)argc; (void)argv;
   char buf[16];
   const char *msg = "hello";
-  exo_cap cap = {0};
+  exo_cap cap = {0, 0};
   cap_send(cap, msg, 5);
   cap_recv(cap, buf, 5);
   buf[5] = '\0';

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -14,7 +14,7 @@ void streams_stop(void) { printf(1, "streams_stop called\n"); }
 void streams_yield(void) { printf(1, "streams_yield called\n"); }
 
 int main(int argc, char *argv[]) {
-  exo_cap cap = {0};
+  exo_cap cap = {0, 0};
   printf(1, "STREAMS/exo yield demo\n");
   streams_stop();
   exo_yield_to(cap);


### PR DESCRIPTION
## Summary
- extend `exo_cap` and `exo_blockcap` with an `owner` field
- tag new capabilities with the allocating process id
- validate capability owners before using them
- propagate owner field in syscalls and IPC helpers

## Testing
- `make fs.img` *(fails: Makefile missing separator)*