### PR TITLE
Implement gas budgeting for exokernel tasks

### DIFF
--- a/caplib.h
+++ b/caplib.h
@@ -9,6 +9,8 @@ int cap_alloc_block(uint dev, exo_blockcap *cap);
 int cap_bind_block(exo_blockcap *cap, void *data, int write);
 int cap_flush_block(exo_blockcap *cap, void *data);
 int cap_set_timer(void (*handler)(void));
+int cap_set_gas(uint64 amount);
+int cap_get_gas(void);
 void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);

--- a/proc.h
+++ b/proc.h
@@ -83,13 +83,14 @@ struct proc {
   char name[16];               // Process name (debugging)
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
+  uint64 gas_remaining;        // Remaining CPU budget
 };
 
 // Ensure scheduler relies on fixed struct proc size
 #ifdef __x86_64__
-_Static_assert(sizeof(struct proc) == 240, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 248, "struct proc size incorrect");
 #else
-_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 144, "struct proc size incorrect");
 #endif
 
 

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -142,6 +142,7 @@ found:
   p->pid = nextpid++;
   p->pctr_cap = nextpctr_cap++;
   p->pctr_signal = 0;
+  p->gas_remaining = 0;
   pctr_insert(p);
 
   release(&ptable.lock);
@@ -402,7 +403,7 @@ scheduler(void)
     acquire(&ptable.lock);
     found = 0;
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
-      if(p->state != RUNNABLE)
+      if(p->state != RUNNABLE || p->gas_remaining == 0)
         continue;
       found = 1;
 

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -160,6 +160,8 @@ extern int sys_exo_recv(void);
 extern int sys_endpoint_send(void);
 extern int sys_endpoint_recv(void);
 extern int sys_proc_alloc(void);
+extern int sys_set_gas(void);
+extern int sys_get_gas(void);
 extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
@@ -199,6 +201,8 @@ static int (*syscalls[])(void) = {
     [SYS_endpoint_send] sys_endpoint_send,
     [SYS_endpoint_recv] sys_endpoint_recv,
     [SYS_proc_alloc] sys_proc_alloc,
+    [SYS_set_gas] sys_set_gas,
+    [SYS_get_gas] sys_get_gas,
     [SYS_ipc_fast] sys_ipc_fast,
 };
 

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -254,4 +254,16 @@ int sys_proc_alloc(void) {
   return cap.pa;
 }
 
+int sys_set_gas(void) {
+  uint64 amount;
+  if (argint(0, (int *)&amount) < 0)
+    return -1;
+  myproc()->gas_remaining = amount;
+  return 0;
+}
+
+int sys_get_gas(void) {
+  return (int)myproc()->gas_remaining;
+}
+
 // Provided by fastipc.c

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -51,6 +51,15 @@ void trap(struct trapframe *tf) {
       wakeup(&ticks);
       release(&tickslock);
     }
+    if (myproc()) {
+      if (myproc()->gas_remaining > 0)
+        myproc()->gas_remaining--;
+      if (myproc()->gas_remaining == 0) {
+        lapiceoi();
+        yield();
+        break;
+      }
+    }
     lapiceoi();
     if (myproc() && myproc()->timer_upcall && (tf->cs & 3) == DPL_USER) {
 #ifndef __x86_64__

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -19,6 +19,8 @@ int cap_flush_block(exo_blockcap *cap, void *data) {
 }
 
 int cap_set_timer(void (*handler)(void)) { return set_timer_upcall(handler); }
+int cap_set_gas(uint64 amount) { return set_gas(amount); }
+int cap_get_gas(void) { return get_gas(); }
 
 void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);

--- a/src-uland/libos/sched.c
+++ b/src-uland/libos/sched.c
@@ -5,6 +5,7 @@
 static exo_cap runq[MAX_PROCS];
 static int nprocs = 0;
 static int cur = -1;
+#define GAS_SLICE 5
 
 void sched_add(exo_cap cap) {
     if(nprocs < MAX_PROCS)
@@ -14,7 +15,10 @@ void sched_add(exo_cap cap) {
 static void sched_tick(void) {
     if(nprocs == 0)
         return;
+    if(get_gas() > 0)
+        return;
     cur = (cur + 1) % nprocs;
+    set_gas(GAS_SLICE);
     cap_yield_to_cap(runq[cur]);
 }
 
@@ -24,6 +28,11 @@ void sched_install_timer(void) {
 
 void sched_run(void) {
     sched_install_timer();
+    if(nprocs > 0){
+        cur = 0;
+        set_gas(GAS_SLICE);
+        cap_yield_to_cap(runq[cur]);
+    }
     while(1)
         sched_tick();
 }

--- a/syscall.h
+++ b/syscall.h
@@ -36,5 +36,7 @@
 #define SYS_endpoint_send 33
 #define SYS_endpoint_recv 34
 #define SYS_proc_alloc 35
+#define SYS_set_gas 36
+#define SYS_get_gas 37
 #define SYS_ipc_fast 0x30
 

--- a/user.h
+++ b/user.h
@@ -40,6 +40,8 @@ int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_flush_block(exo_blockcap *cap);
 int exo_yield_to(exo_cap target);
+int set_gas(uint64 amount);
+int get_gas(void);
 int exo_send(exo_cap dest, const void *buf, uint64 len);
 int exo_recv(exo_cap src, void *buf, uint64 len);
 int endpoint_send(zipc_msg_t *msg);

--- a/usys.S
+++ b/usys.S
@@ -69,5 +69,7 @@ SYSCALL(exo_recv)
 SYSCALL(endpoint_send)
 SYSCALL(endpoint_recv)
 SYSCALL(proc_alloc)
+SYSCALL(set_gas)
+SYSCALL(get_gas)
 
 


### PR DESCRIPTION
## Summary
- add `gas_remaining` field to `struct proc`
- introduce `set_gas` and `get_gas` syscalls
- track gas countdown in timer interrupt and skip processes with no gas
- expose gas management helpers in user library
- adjust libos scheduler to refill gas slices when tasks exhaust their budgets

## Testing
- `make qemu-nox` *(fails: Makefile missing separator)*