### PR TITLE
Add DAG scheduler skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ OBJS = \
        $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/fastipc.o\
        $(KERNEL_DIR)/endpoint.o\
+       $(KERNEL_DIR)/dag_sched.o
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o
@@ -260,6 +261,7 @@ UPROGS=\
         _zombie\
         _phi\
         _exo_stream_demo\
+        _dag_demo\
         _ipc_test\
         _kbdserv\
         _rcrs\
@@ -363,6 +365,7 @@ EXTRA=\
         $(ULAND_DIR)/wc.c $(ULAND_DIR)/zombie.c \
         $(ULAND_DIR)/phi.c \
         $(ULAND_DIR)/user/exo_stream_demo.c \
+        $(ULAND_DIR)/user/dag_demo.c \
         $(ULAND_DIR)/printf.c $(ULAND_DIR)/umalloc.c\
 	README dot-bochsrc *.pl toc.* runoff runoff1 runoff.list\
 	.gdbinit.tmpl gdbutil\

--- a/dag.h
+++ b/dag.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+
+struct dag_node;
+
+struct dag_node_list {
+  struct dag_node *node;
+  struct dag_node_list *next;
+};
+
+struct dag_node {
+  exo_cap ctx;
+  int pending;
+  struct dag_node_list *children;
+  struct dag_node *next;
+};
+
+void dag_node_init(struct dag_node *n, exo_cap ctx);
+void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
+void dag_sched_submit(struct dag_node *node);
+void dag_sched_init(void);

--- a/defs.h
+++ b/defs.h
@@ -33,6 +33,7 @@ struct exo_blockcap;
 struct exo_sched_ops;
 struct exo_stream;
 struct endpoint;
+struct dag_node;
 
 // process table defined in proc.c
 extern struct ptable ptable;
@@ -259,6 +260,10 @@ void            fastipc_send(zipc_msg_t *);
 int             sys_ipc_fast(void);
 void            endpoint_send(struct endpoint *, zipc_msg_t *);
 int             endpoint_recv(struct endpoint *, zipc_msg_t *);
+void            dag_sched_init(void);
+void            dag_node_init(struct dag_node *, exo_cap);
+void            dag_node_add_dep(struct dag_node *, struct dag_node *);
+void            dag_sched_submit(struct dag_node *);
 
 
 // number of elements in fixed-size array

--- a/src-kernel/dag_sched.c
+++ b/src-kernel/dag_sched.c
@@ -1,0 +1,103 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "dag.h"
+#include "exo_stream.h"
+#include "exo_cpu.h"
+
+static struct spinlock dag_lock;
+static struct dag_node *ready_head;
+
+static struct exo_sched_ops dag_ops;
+static struct exo_stream dag_stream;
+
+void
+dag_node_init(struct dag_node *n, exo_cap ctx)
+{
+  memset(n, 0, sizeof(*n));
+  n->ctx = ctx;
+}
+
+void
+dag_node_add_dep(struct dag_node *parent, struct dag_node *child)
+{
+  struct dag_node_list *l = (struct dag_node_list *)kalloc();
+  if(!l)
+    return;
+  l->node = child;
+  l->next = parent->children;
+  parent->children = l;
+  child->pending++;
+}
+
+static void
+enqueue_ready(struct dag_node *n)
+{
+  n->next = ready_head;
+  ready_head = n;
+}
+
+void
+dag_sched_submit(struct dag_node *n)
+{
+  acquire(&dag_lock);
+  if(n->pending == 0)
+    enqueue_ready(n);
+  release(&dag_lock);
+}
+
+static struct dag_node *
+dequeue_ready(void)
+{
+  struct dag_node *n = ready_head;
+  if(n)
+    ready_head = n->next;
+  return n;
+}
+
+static void
+dag_mark_done(struct dag_node *n)
+{
+  struct dag_node_list *l;
+  for(l = n->children; l; l = l->next){
+    struct dag_node *child = l->node;
+    if(--child->pending == 0)
+      enqueue_ready(child);
+  }
+}
+
+static void
+dag_yield(void)
+{
+  struct dag_node *n;
+
+  acquire(&dag_lock);
+  n = dequeue_ready();
+  release(&dag_lock);
+
+  if(!n)
+    return;
+
+  exo_yield_to(n->ctx);
+
+  acquire(&dag_lock);
+  dag_mark_done(n);
+  release(&dag_lock);
+}
+
+static void
+dag_halt(void)
+{
+  // nothing
+}
+
+void
+dag_sched_init(void)
+{
+  initlock(&dag_lock, "dag");
+  dag_ops.halt = dag_halt;
+  dag_ops.yield = dag_yield;
+  dag_ops.next = 0;
+  dag_stream.head = &dag_ops;
+  exo_stream_register(&dag_stream);
+}

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -4,6 +4,7 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "proc.h"
+#include "dag.h"
 #include "x86.h"
 
 static void startothers(void);
@@ -34,7 +35,8 @@ main(void)
   tvinit();        // trap vectors
   binit();         // buffer cache
   fileinit();      // file table
-  ideinit();       // disk 
+  ideinit();       // disk
+  dag_sched_init(); // initialize DAG scheduler
   startothers();   // start other processors
   kinit2(P2V(4*1024*1024), P2V(PHYSTOP)); // must come after startothers()
   userinit();      // first user process

--- a/src-uland/user/dag_demo.c
+++ b/src-uland/user/dag_demo.c
@@ -1,0 +1,31 @@
+#include "caplib.h"
+#include "types.h"
+#include "user.h"
+#include "dag.h"
+
+// Stub exo_yield_to since kernel support is unavailable
+int exo_yield_to(exo_cap target) {
+  printf(1, "exo_yield_to called with cap %p\n", (void *)target.pa);
+  return 0;
+}
+
+static struct dag_node a, b, c;
+
+static void setup(void) {
+  exo_cap cap = {0};
+  dag_node_init(&a, cap);
+  dag_node_init(&b, cap);
+  dag_node_init(&c, cap);
+  dag_node_add_dep(&a, &c);
+  dag_node_add_dep(&b, &c);
+  dag_sched_submit(&a);
+  dag_sched_submit(&b);
+  dag_sched_submit(&c);
+}
+
+int main(int argc, char *argv[]) {
+  printf(1, "DAG scheduler demo\n");
+  setup();
+  exo_stream_yield();
+  exit();
+}


### PR DESCRIPTION
## Summary
- add `dag.h` with DAG node definitions
- implement a simple DAG scheduler in `dag_sched.c`
- hook the scheduler into system startup
- expose DAG APIs in `defs.h`
- include a small `dag_demo` program
- adjust build rules for the new files

## Testing
- `make --version`
- `make -k` *(fails: `Makefile:210: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.`)*