### PR TITLE
Enable RCU style buffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ OBJS = \
         $(KERNEL_DIR)/proc.o\
         $(KERNEL_DIR)/sleeplock.o\
         $(KERNEL_DIR)/spinlock.o\
+        $(KERNEL_DIR)/rcu.o\
         $(KERNEL_DIR)/string.o\
         $(KERNEL_DIR)/syscall.o\
         $(KERNEL_DIR)/sysfile.o\
@@ -199,16 +200,14 @@ $(KERNEL_DIR)/vectors.S: vectors.pl
 	./vectors.pl > $@
 
 LIBOS_OBJS = \
-        $(ULAND_DIR)/ulib.o \
-       usys.o \
+        $(ULAND_DIR)/usys.o \
         $(ULAND_DIR)/printf.o \
         $(ULAND_DIR)/umalloc.o \
-       $(KERNEL_DIR)/swtch.o \
+        $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
+        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o
 

--- a/buf.h
+++ b/buf.h
@@ -6,6 +6,7 @@ struct buf {
   uint blockno;
   struct sleeplock lock;
   size_t refcnt;
+  size_t rcref; // number of read-side references
   struct buf *prev; // LRU cache list
   struct buf *next;
   struct buf *qnext; // disk queue

--- a/defs.h
+++ b/defs.h
@@ -260,6 +260,12 @@ int             sys_ipc_fast(void);
 void            endpoint_send(struct endpoint *, zipc_msg_t *);
 int             endpoint_recv(struct endpoint *, zipc_msg_t *);
 
+// rcu.c
+void            rcuinit(void);
+void            rcu_read_lock(void);
+void            rcu_read_unlock(void);
+void            rcu_synchronize(void);
+
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -30,6 +30,7 @@ main(void)
   ioapicinit();    // another interrupt controller
   consoleinit();   // console hardware
   uartinit();      // serial port
+  rcuinit();       // rcu subsystem
   pinit();         // process table
   tvinit();        // trap vectors
   binit();         // buffer cache

--- a/src-kernel/rcu.c
+++ b/src-kernel/rcu.c
@@ -1,0 +1,48 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "proc.h"
+
+static struct {
+  struct spinlock lock;
+  int readers;
+} rcu_state;
+
+void
+rcuinit(void)
+{
+  initlock(&rcu_state.lock, "rcu");
+  rcu_state.readers = 0;
+}
+
+void
+rcu_read_lock(void)
+{
+  acquire(&rcu_state.lock);
+  rcu_state.readers++;
+  release(&rcu_state.lock);
+}
+
+void
+rcu_read_unlock(void)
+{
+  acquire(&rcu_state.lock);
+  rcu_state.readers--;
+  if(rcu_state.readers < 0)
+    panic("rcu_read_unlock");
+  release(&rcu_state.lock);
+}
+
+void
+rcu_synchronize(void)
+{
+  for(;;){
+    acquire(&rcu_state.lock);
+    if(rcu_state.readers == 0){
+      release(&rcu_state.lock);
+      break;
+    }
+    release(&rcu_state.lock);
+    yield();
+  }
+}

--- a/src-uland/usertests.c
+++ b/src-uland/usertests.c
@@ -932,6 +932,31 @@ bigdir(void)
 }
 
 void
+rcuconcurrent(void)
+{
+  int pid, i, fd;
+  char buf[64];
+
+  printf(1, "rcu concurrent read test\n");
+  for(i = 0; i < 4; i++){
+    pid = fork();
+    if(pid == 0){
+      for(int j = 0; j < 100; j++){
+        fd = open("README", 0);
+        if(fd >= 0){
+          read(fd, buf, sizeof(buf));
+          close(fd);
+        }
+      }
+      exit();
+    }
+  }
+  for(i = 0; i < 4; i++)
+    wait();
+  printf(1, "rcu concurrent read test done\n");
+}
+
+void
 subdir(void)
 {
   int fd, cc;
@@ -1794,6 +1819,7 @@ main(int argc, char *argv[])
   iref();
   forktest();
   bigdir(); // slow
+  rcuconcurrent();
 
   uio();
 


### PR DESCRIPTION
## Summary
- implement a very small RCU framework
- maintain RCU reference counts for buffers
- delay buffer release with an RCU grace period
- add a concurrent read test

## Testing
- `make` *(fails: `SYS_exo_flush_block` undeclared)*