### PR TITLE
Switch to ticket-based spinlocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,10 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/umalloc.o \
        $(KERNEL_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
+       $(ULAND_DIR)/math_core.o \
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
+       $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o
 

--- a/libos/spinlock.h
+++ b/libos/spinlock.h
@@ -1,5 +1,11 @@
 #pragma once
-struct spinlock { int locked; };
+
+
+struct ticketlock {
+  _Atomic unsigned short head;
+  _Atomic unsigned short tail;
+};
+struct spinlock { struct ticketlock ticket; };
 static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,8 +1,14 @@
 #pragma once
 
-// Mutual exclusion lock.
+
+// Ticket-based mutual exclusion lock.
+struct ticketlock {
+  _Atomic uint16_t head;
+  _Atomic uint16_t tail;
+};
+
 struct spinlock {
-  uint locked;       // Is the lock held?
+  struct ticketlock ticket; // Ticket lock implementation
 
   // For debugging:
   char *name;        // Name of lock.


### PR DESCRIPTION
## Summary
- define a `ticketlock` structure
- implement ticket-based acquire/release logic
- adjust Makefile line continuations

## Testing
- `gcc -std=gnu2x -I. -Ikernel -Isrc-kernel -c src-kernel/spinlock.c -o /tmp/spinlock.o`