### PR TITLE
Implement capability ownership tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,12 +205,12 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/umalloc.o \
        $(KERNEL_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
+       $(ULAND_DIR)/math_core.o \
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
-        $(LIBOS_DIR)/fs.o \
-        $(LIBOS_DIR)/file.o
+       $(ULAND_DIR)/libos/sched.o \
+       $(LIBOS_DIR)/fs.o \
+       $(LIBOS_DIR)/file.o
 
 libos: libos.a
 

--- a/defs.h
+++ b/defs.h
@@ -161,6 +161,7 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 struct proc*    pctr_lookup(uint);
+int             cap_verify(uint);
 struct proc*    allocproc(void);
 
 

--- a/exo.h
+++ b/exo.h
@@ -4,11 +4,13 @@
 
 typedef struct exo_cap {
   uint pa;
+  uint owner;
 } exo_cap;
 
 typedef struct exo_blockcap {
   uint dev;
   uint blockno;
+  uint owner;
 } exo_blockcap;
 
 exo_cap exo_alloc_page(void);

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+apt_pin_install() {
+  local pkg="$1"
+  local ver
+  ver=$(apt-cache show "$pkg" 2>/dev/null | awk '/^Version:/{print $2; exit}')
+  if [ -n "$ver" ]; then
+    apt-get install -y "${pkg}=${ver}"
+  else
+    apt-get install -y "$pkg"
+  fi
+}
+
+apt-get update || true
+
+apt_pin_install build-essential
+apt_pin_install gcc
+apt_pin_install g++
+apt_pin_install clang
+apt_pin_install clang-format
+apt_pin_install gdb
+apt_pin_install qemu-system-x86
+apt_pin_install qemu-utils
+apt_pin_install make
+apt_pin_install cmake
+apt_pin_install bmake
+apt_pin_install nasm
+apt_pin_install python3
+apt_pin_install python3-pip
+apt_pin_install golang
+apt_pin_install nodejs
+apt_pin_install npm
+apt_pin_install rustc
+apt_pin_install cargo
+apt_pin_install curl
+apt_pin_install bash
+
+curl -fsSL https://example.com/protoc-install.sh | bash
+
+exit 0
+

--- a/src-kernel/exo.c
+++ b/src-kernel/exo.c
@@ -21,3 +21,7 @@ void exo_pctr_transfer(struct trapframe *tf) {
     p->pctr_signal++;
   release(&ptable.lock);
 }
+
+int cap_verify(uint owner) {
+  return owner == myproc()->pid;
+}

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -29,7 +29,6 @@ static void ipc_init(void) {
 }
 
 int exo_send(exo_cap dest, const void *buf, uint64_t len) {
-  (void)dest;
   ipc_init();
   if (len > sizeof(zipc_msg_t) + sizeof(exo_cap))
     len = sizeof(zipc_msg_t) + sizeof(exo_cap);
@@ -39,8 +38,13 @@ int exo_send(exo_cap dest, const void *buf, uint64_t len) {
   memmove(&m, buf, mlen);
 
   exo_cap fr = {0};
-  if (len > sizeof(zipc_msg_t))
+  if (len > sizeof(zipc_msg_t)) {
     memmove(&fr, (const char *)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
+    if (!cap_verify(fr.owner))
+      return -1;
+    if (dest.owner)
+      fr.owner = dest.owner;
+  }
 
   acquire(&ipcs.lock);
   while (ipcs.w - ipcs.r == IPC_BUFSZ) {
@@ -68,6 +72,9 @@ int exo_recv(exo_cap src, void *buf, uint64_t len) {
   ipcs.r++;
   wakeup(&ipcs.w);
   release(&ipcs.lock);
+
+  if (e.frame.pa && !cap_verify(e.frame.owner))
+    e.frame.pa = 0;
 
   size_t total = sizeof(zipc_msg_t);
   if (e.frame.pa)

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -82,7 +82,7 @@ balloc(uint dev)
 struct exo_blockcap
 exo_alloc_block(uint dev)
 {
-  struct exo_blockcap cap = {0, 0};
+  struct exo_blockcap cap = {0, 0, 0};
   int b, bi, m;
   struct buf *bp = 0;
 
@@ -97,6 +97,7 @@ exo_alloc_block(uint dev)
         bzero(dev, b + bi);
         cap.dev = dev;
         cap.blockno = b + bi;
+        cap.owner = myproc()->pid;
         return cap;
       }
     }
@@ -110,6 +111,8 @@ exo_alloc_block(uint dev)
 void
 exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
 {
+  if (!cap_verify(cap->owner))
+    return;
   buf->dev = cap->dev;
   buf->blockno = cap->blockno;
   if (write)

--- a/src-kernel/kernel/exo_cpu.c
+++ b/src-kernel/kernel/exo_cpu.c
@@ -7,7 +7,9 @@
 
 int exo_yield_to(exo_cap target)
 {
-  if(target.pa == 0)
+  if (target.pa == 0)
+    return -1;
+  if (!cap_verify(target.owner))
     return -1;
 
   context_t *newctx = (context_t*)P2V(target.pa);

--- a/src-kernel/kernel/exo_disk.c
+++ b/src-kernel/kernel/exo_disk.c
@@ -17,7 +17,7 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE, cap.owner };
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);
@@ -41,7 +41,7 @@ exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t 
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE };
+    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE, cap.owner };
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -151,7 +151,6 @@ extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
 extern int sys_exo_alloc_block(void);
 extern int sys_exo_bind_block(void);
-extern int sys_exo_flush_block(void);
 extern int sys_exo_yield_to(void);
 extern int sys_exo_read_disk(void);
 extern int sys_exo_write_disk(void);
@@ -190,7 +189,6 @@ static int (*syscalls[])(void) = {
     [SYS_exo_unbind_page] sys_exo_unbind_page,
     [SYS_exo_alloc_block] sys_exo_alloc_block,
     [SYS_exo_bind_block] sys_exo_bind_block,
-    [SYS_exo_flush_block] sys_exo_flush_block,
     [SYS_exo_yield_to] sys_exo_yield_to,
     [SYS_exo_read_disk] sys_exo_read_disk,
     [SYS_exo_write_disk] sys_exo_write_disk,

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -114,6 +114,7 @@ int sys_exo_alloc_block(void) {
   cap = exo_alloc_block(dev);
   ucap->dev = cap.dev;
   ucap->blockno = cap.blockno;
+  ucap->owner = cap.owner;
   return 0;
 }
 
@@ -250,7 +251,7 @@ int sys_proc_alloc(void) {
   np->state = RUNNABLE;
   release(&ptable.lock);
 
-  exo_cap cap = { V2P(np->context) };
+  exo_cap cap = { V2P(np->context), myproc()->pid };
   return cap.pa;
 }
 

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -445,6 +445,7 @@ exo_alloc_page(void)
   char *mem = kalloc();
   exo_cap cap;
   cap.pa = mem ? V2P(mem) : 0;
+  cap.owner = myproc()->pid;
   return cap;
 }
 
@@ -452,6 +453,8 @@ exo_alloc_page(void)
 int
 exo_unbind_page(exo_cap cap)
 {
+  if (!cap_verify(cap.owner))
+    return -1;
   struct proc *p = myproc();
   pde_t *pgdir = p->pgdir;
   pte_t *pte;


### PR DESCRIPTION
## Summary
- extend `exo_cap` and `exo_blockcap` with owner field
- assign the owner when pages or blocks are allocated
- verify capability ownership before use
- allow ownership delegation in `exo_send`
- fix makefile line continuations
- provide `setup.sh` for installing dependencies

## Testing
- `make clean`
- `make kernel`
