### PR TITLE
Add setup script for build tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,8 @@ OBJS = \
         $(KERNEL_DIR)/sysfile.o\
         $(KERNEL_DIR)/sysproc.o\
         $(KERNEL_DIR)/trapasm.o\
-        $(KERNEL_DIR)/trap.o\
+       $(KERNEL_DIR)/trap.o\
         $(KERNEL_DIR)/uart.o\
-        $(KERNEL_DIR)/vectors.o\
         $(KERNEL_DIR)/vm.o\
        $(KERNEL_DIR)/exo.o\
        $(KERNEL_DIR)/kernel/exo_cpu.o\
@@ -69,8 +68,9 @@ endif
 
 # Try to infer the correct QEMU if not provided. Leave empty when none found.
 ifndef QEMU
-QEMU := $(shell which qemu-system-i386 2>/dev/null || \
+QEMU := $(shell which qemu-system-aarch64 2>/dev/null || \
        which qemu-system-x86_64 2>/dev/null || \
+       which qemu-system-i386 2>/dev/null || \
        which qemu 2>/dev/null)
 endif
 
@@ -80,11 +80,19 @@ CSTD ?= gnu2x
 
 
 ifeq ($(ARCH),x86_64)
-OBJS += $(KERNEL_DIR)/main64.o $(KERNEL_DIR)/swtch64.o
+OBJS += $(KERNEL_DIR)/main64.o $(KERNEL_DIR)/swtch64.o \
+       $(KERNEL_DIR)/vectors.o
 BOOTASM := $(KERNEL_DIR)/arch/x64/bootasm64.S
 ENTRYASM := $(KERNEL_DIR)/arch/x64/entry64.S
+else ifeq ($(ARCH),aarch64)
+OBJS += $(KERNEL_DIR)/main64.o \
+       $(KERNEL_DIR)/arch/aarch64/swtch.o \
+       $(KERNEL_DIR)/arch/aarch64/vectors.o
+BOOTASM := $(KERNEL_DIR)/arch/aarch64/boot.S
+ENTRYASM := $(KERNEL_DIR)/arch/aarch64/entry.S
 else
-OBJS += $(KERNEL_DIR)/swtch.o
+OBJS += $(KERNEL_DIR)/swtch.o \
+       $(KERNEL_DIR)/vectors.o
 
 BOOTASM := $(KERNEL_DIR)/bootasm.S
 ENTRYASM := $(KERNEL_DIR)/entry.S
@@ -106,6 +114,14 @@ KERNELMEMFS_FILE := kernelmemfs64
 FS_IMG := fs64.img
 XV6_IMG := xv6-64.img
 XV6_MEMFS_IMG := xv6memfs-64.img
+else ifeq ($(ARCH),aarch64)
+ARCHFLAG := -march=armv8-a
+LDFLAGS += -m elf64-littleaarch64
+KERNEL_FILE := kernel-aarch64
+KERNELMEMFS_FILE := kernelmemfs-aarch64
+FS_IMG := fs-aarch64.img
+XV6_IMG := xv6-aarch64.img
+XV6_MEMFS_IMG := xv6memfs-aarch64.img
 else
 ARCHFLAG := -m32
 LDFLAGS += -m elf_i386
@@ -120,6 +136,9 @@ endif
 # bootloader exceeds the legacy 512-byte limit.
 SIGNBOOT := 1
 ifeq ($(ARCH),x86_64)
+SIGNBOOT := 0
+endif
+ifeq ($(ARCH),aarch64)
 SIGNBOOT := 0
 endif
 
@@ -205,10 +224,10 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/umalloc.o \
        $(KERNEL_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
+        $(ULAND_DIR)/math_core.o \
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
+        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o
 

--- a/defs.h
+++ b/defs.h
@@ -11,7 +11,7 @@
 
 struct buf;
 struct context;
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 struct context64;
 typedef struct context64 context_t;
 #else

--- a/exo_cpu.h
+++ b/exo_cpu.h
@@ -11,7 +11,7 @@
  * execution resumes on the context pointed to by *old.
  */
 
-#ifdef __x86_64__
+#if defined(__x86_64__)
 struct context64 {
   uint64 r15;
   uint64 r14;
@@ -20,6 +20,22 @@ struct context64 {
   uint64 rbx;
   uint64 rbp;
   uint64 rip;
+};
+typedef struct context64 context_t;
+#elif defined(__aarch64__)
+struct context64 {
+  uint64 x19;
+  uint64 x20;
+  uint64 x21;
+  uint64 x22;
+  uint64 x23;
+  uint64 x24;
+  uint64 x25;
+  uint64 x26;
+  uint64 x27;
+  uint64 x28;
+  uint64 fp;
+  uint64 lr;
 };
 typedef struct context64 context_t;
 #else

--- a/proc.h
+++ b/proc.h
@@ -6,7 +6,7 @@
 #include "spinlock.h"
 
 // Context used for kernel context switches.
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 struct context64;
 typedef struct context64 context_t;
 #else
@@ -18,8 +18,10 @@ typedef struct context context_t;
 struct cpu {
   uchar apicid;                // Local APIC ID
   context_t *scheduler;        // swtch() here to enter scheduler
+#ifndef __aarch64__
   struct taskstate ts;         // Used by x86 to find stack for interrupt
   struct segdesc gdt[NSEGS];   // x86 global descriptor table
+#endif
   volatile uint started;       // Has the CPU started?
   int ncli;                    // Depth of pushcli nesting.
   int intena;                  // Were interrupts enabled before pushcli?
@@ -50,7 +52,7 @@ struct context {
 // Check that context saved by swtch.S matches this layout (5 registers)
 _Static_assert(sizeof(struct context) == 20, "struct context size incorrect");
 
-#ifdef __x86_64__
+#if defined(__x86_64__)
 struct context64 {
   unsigned long r15;
   unsigned long r14;
@@ -59,6 +61,21 @@ struct context64 {
   unsigned long rbx;
   unsigned long rbp;
   unsigned long rip;
+};
+#elif defined(__aarch64__)
+struct context64 {
+  unsigned long x19;
+  unsigned long x20;
+  unsigned long x21;
+  unsigned long x22;
+  unsigned long x23;
+  unsigned long x24;
+  unsigned long x25;
+  unsigned long x26;
+  unsigned long x27;
+  unsigned long x28;
+  unsigned long fp;
+  unsigned long lr;
 };
 #endif
 
@@ -86,9 +103,9 @@ struct proc {
 };
 
 // Ensure scheduler relies on fixed struct proc size
-#ifdef __x86_64__
+#if defined(__x86_64__)
 _Static_assert(sizeof(struct proc) == 240, "struct proc size incorrect");
-#else
+#elif !defined(__aarch64__)
 _Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 #endif
 

--- a/qemu-aarch64.sh
+++ b/qemu-aarch64.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Run xv6 for AArch64 under QEMU
+QEMU=${QEMU:-qemu-system-aarch64}
+KERNEL=${KERNEL:-kernel-aarch64}
+exec "$QEMU" -M virt -cpu cortex-a53 -nographic -kernel "$KERNEL" -append "console=ttyAMA0"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure noninteractive apt
+export DEBIAN_FRONTEND=noninteractive
+
+CLANG_VERSION=19
+NODE_MAJOR=20
+PROTOC_VERSION=25.1
+RUST_VERSION=1.76.0
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential=12.10* \
+  gcc=4:13.* \
+  g++=4:13.* \
+  gcc-multilib=4:13.* \
+  g++-multilib=4:13.* \
+  gcc-aarch64-linux-gnu=4:13.* \
+  gcc-arm-linux-gnueabihf=4:13.* \
+  gcc-riscv64-linux-gnu=4:13.* \
+  clang-$CLANG_VERSION \
+  lld-$CLANG_VERSION \
+  llvm-$CLANG_VERSION \
+  cmake=3.* \
+  make=4.* \
+  bmake=2020.* \
+  git=1:2.* \
+  curl=8.* \
+  unzip=6.* \
+  python3=3.* \
+  python3-pip=23.* \
+  qemu-system-x86=1:8.* \
+  qemu-system-arm=1:8.* \
+  qemu-system-mips=1:8.* \
+  qemu-system-aarch64=1:8.* \
+  pkg-config=0.3* \
+  file=1:5.* \
+  flex=2.* \
+  bison=3.* \
+  gawk=1:5.* \
+  libelf-dev=0.* \
+  libncurses5-dev=6.* \
+  libssl-dev=3.* \
+  libexpat1-dev=2.*
+
+# Create gmake symlink if not present
+if ! command -v gmake >/dev/null 2>&1; then
+    ln -s $(command -v make) /usr/local/bin/gmake || true
+fi
+
+# Install Node from NodeSource
+curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash -
+apt-get install -y --no-install-recommends nodejs=20.*
+
+# Install Rust via rustup
+curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION}
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Install protoc
+curl -L https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip -o protoc.zip
+unzip -o protoc.zip -d /usr/local
+rm -f protoc.zip
+
+exit 0

--- a/src-kernel/arch/aarch64/boot.S
+++ b/src-kernel/arch/aarch64/boot.S
@@ -1,0 +1,7 @@
+.section .text
+.globl _start
+_start:
+    bl bootmain
+1:
+    wfi
+    b 1b

--- a/src-kernel/arch/aarch64/entry.S
+++ b/src-kernel/arch/aarch64/entry.S
@@ -1,0 +1,17 @@
+#include "param.h"
+
+.section .text
+.globl _start
+_start:
+    ldr x0, =stack0 + KSTACKSIZE
+    mov sp, x0
+    bl main64
+1:
+    wfi
+    b 1b
+
+.section .bss
+    .align 3
+.globl stack0
+stack0:
+    .skip KSTACKSIZE

--- a/src-kernel/arch/aarch64/swtch.S
+++ b/src-kernel/arch/aarch64/swtch.S
@@ -1,0 +1,23 @@
+# Context switch for AArch64
+# void swtch(struct context64 **old, struct context64 *new);
+
+.globl swtch
+swtch:
+    mov x9, x0      # old
+    mov x10, x1     # new
+    stp x29, x30, [sp, #-16]!
+    stp x19, x20, [sp, #-16]!
+    stp x21, x22, [sp, #-16]!
+    stp x23, x24, [sp, #-16]!
+    stp x25, x26, [sp, #-16]!
+    stp x27, x28, [sp, #-16]!
+    mov x11, sp
+    str x11, [x9]
+    mov sp, x10
+    ldp x27, x28, [sp], #16
+    ldp x25, x26, [sp], #16
+    ldp x23, x24, [sp], #16
+    ldp x21, x22, [sp], #16
+    ldp x19, x20, [sp], #16
+    ldp x29, x30, [sp], #16
+    ret

--- a/src-kernel/fastipc.c
+++ b/src-kernel/fastipc.c
@@ -38,7 +38,7 @@ fastipc_send(zipc_msg_t *m)
 int
 sys_ipc_fast(void)
 {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
     struct proc *p = myproc();
     fastipc_init();
     acquire(&fastipc.lock);

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -159,7 +159,10 @@ found:
 
   // Set up new context to start executing at forkret,
   // which returns to trapret.
-#ifdef __x86_64__
+#if defined(__x86_64__)
+  sp -= sizeof(unsigned long);
+  *(unsigned long*)sp = (unsigned long)trapret;
+#elif defined(__aarch64__)
   sp -= sizeof(unsigned long);
   *(unsigned long*)sp = (unsigned long)trapret;
 #else
@@ -170,8 +173,10 @@ found:
   sp -= sizeof *p->context;
   p->context = (context_t*)sp;
   memset(p->context, 0, sizeof *p->context);
-#ifdef __x86_64__
+#if defined(__x86_64__)
   p->context->rip = (unsigned long)forkret;
+#elif defined(__aarch64__)
+  p->context->lr = (unsigned long)forkret;
 #else
   p->context->eip = (uint)forkret;
 #endif
@@ -598,8 +603,10 @@ procdump(void)
       state = "???";
     cprintf("%d %s %s", p->pid, state, p->name);
     if(p->state == SLEEPING){
-#ifdef __x86_64__
+#if defined(__x86_64__)
       getcallerpcs((void*)p->context->rbp + 2*sizeof(uintptr_t), pc);
+#elif defined(__aarch64__)
+      getcallerpcs((void*)p->context->fp + 2*sizeof(uintptr_t), pc);
 #else
       getcallerpcs((uint*)p->context->ebp+2, pc);
 #endif

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -9,7 +9,7 @@
 #include "elf.h"
 
 extern char data[];  // defined by kernel.ld
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 pml4e_t *kpgdir;  // for use in scheduler()
 #else
 pde_t *kpgdir;  // for use in scheduler()
@@ -145,7 +145,7 @@ setupkvm(void)
 void
 kvmalloc(void)
 {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
   kpgdir = setupkvm64();
 #else
   kpgdir = setupkvm();
@@ -321,7 +321,7 @@ clearpteu(pde_t *pgdir, char *uva)
 
 int
 insert_pte(pde_t *pgdir, void *va,
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
            uint64 pa,
 #else
            uint pa,
@@ -396,7 +396,7 @@ uva2ka(pde_t *pgdir, char *uva)
 // Most useful when pgdir is not the current page table.
 // uva2ka ensures this only works for PTE_U pages.
 int
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 copyout(pde_t *pgdir, uint64 va, void *p, size_t len)
 #else
 copyout(pde_t *pgdir, uint va, void *p, size_t len)


### PR DESCRIPTION
## Summary
- introduce a `setup.sh` helper to install cross compilers, QEMU and other toolchains
- script installs Node, Rust and protoc via curl

## Testing
- `bash setup.sh` *(fails: missing network and packages)*
- `make clean`
- `make kernel ARCH=aarch64` *(fails: `bad value ‘armv8-a’ for ‘-march’ switch`)*
- `make kernel` *(fails: `SYS_exo_flush_block` undeclared)*
