### PR TITLE
Implement typed endpoints

### DIFF
--- a/chan.h
+++ b/chan.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "types.h"
 #include "caplib.h"
+#include "ipc.h"
 
 // Generic channel descriptor storing expected message size
 typedef struct chan {
     size_t msg_size;
+    struct msg_type_desc desc;
 } chan_t;
 
 // Allocate a channel expecting messages of size msg_size bytes
@@ -14,8 +16,8 @@ chan_t *chan_create(size_t msg_size);
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-int endpoint_send(chan_t *c, exo_cap dest, const void *msg);
-int endpoint_recv(chan_t *c, exo_cap src, void *msg);
+int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg);
+int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
@@ -32,10 +34,10 @@ int endpoint_recv(chan_t *c, exo_cap src, void *msg);
     }                                                               \
     static inline int name##_send(name##_t *c, exo_cap dest, const type *m){ \
         if(c->base.msg_size != sizeof(type)) return -1;             \
-        return endpoint_send(&c->base, dest, m);                    \
+        return chan_endpoint_send(&c->base, dest, m);                \
     }                                                               \
     static inline int name##_recv(name##_t *c, exo_cap src, type *m){ \
         if(c->base.msg_size != sizeof(type)) return -1;             \
-        return endpoint_recv(&c->base, src, m);                     \
+        return chan_endpoint_recv(&c->base, src, m);                 \
     }
 

--- a/defs.h
+++ b/defs.h
@@ -257,7 +257,9 @@ void            exo_stream_halt(void);
 void            exo_stream_yield(void);
 void            fastipc_send(zipc_msg_t *);
 int             sys_ipc_fast(void);
-void            endpoint_send(struct endpoint *, zipc_msg_t *);
+void            endpoint_config(struct endpoint *, zipc_msg_t *, uint,
+                                struct msg_type_desc *);
+int             endpoint_send(struct endpoint *, zipc_msg_t *);
 int             endpoint_recv(struct endpoint *, zipc_msg_t *);
 
 

--- a/endpoint.h
+++ b/endpoint.h
@@ -8,9 +8,11 @@ struct endpoint {
     uint size;
     uint r, w;
     int inited;
+    struct msg_type_desc *type;
 };
 
 void endpoint_init(struct endpoint *ep);
-void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size);
-void endpoint_send(struct endpoint *ep, zipc_msg_t *m);
+void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+                     struct msg_type_desc *type);
+int endpoint_send(struct endpoint *ep, zipc_msg_t *m);
 int endpoint_recv(struct endpoint *ep, zipc_msg_t *m);

--- a/ipc.h
+++ b/ipc.h
@@ -21,6 +21,14 @@ typedef struct {
   uint64_t w3;
 } zipc_msg_t;
 
+// Descriptor describing the valid byte width of each message word
+struct msg_type_desc {
+  uint8_t w0_sz;
+  uint8_t w1_sz;
+  uint8_t w2_sz;
+  uint8_t w3_sz;
+};
+
 static inline int zipc_call(zipc_msg_t *m) {
   register uint64_t rdi __asm("rdi") = m->badge;
   register uint64_t rsi __asm("rsi") = m->w0;

--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -6,6 +6,30 @@
 
 static struct endpoint global_ep;
 
+static int
+check_msg(struct endpoint *ep, const zipc_msg_t *m)
+{
+    if(!ep->type)
+        return -1;
+    uint8_t sizes[4] = {
+        ep->type->w0_sz,
+        ep->type->w1_sz,
+        ep->type->w2_sz,
+        ep->type->w3_sz
+    };
+    const uint64_t words[4] = {m->w0, m->w1, m->w2, m->w3};
+    for(int i = 0; i < 4; i++){
+        if(sizes[i] > 8)
+            return -1;
+        if(sizes[i] < 8){
+            uint64_t mask = ~((1ULL << (sizes[i]*8)) - 1);
+            if(words[i] & mask)
+                return -1;
+        }
+    }
+    return 0;
+}
+
 void
 endpoint_init(struct endpoint *ep)
 {
@@ -17,27 +41,33 @@ endpoint_init(struct endpoint *ep)
 }
 
 void
-endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size)
+endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+                struct msg_type_desc *type)
 {
     endpoint_init(ep);
     acquire(&ep->lock);
     ep->q = buf;
     ep->size = size;
+    ep->type = type;
     ep->r = ep->w = 0;
     release(&ep->lock);
 }
 
-void
+int
 endpoint_send(struct endpoint *ep, zipc_msg_t *m)
 {
     endpoint_init(ep);
     acquire(&ep->lock);
-    if(ep->q && ep->size && ep->w - ep->r < ep->size){
+    int ok = -1;
+    if(ep->q && ep->size && ep->w - ep->r < ep->size &&
+       check_msg(ep, m) == 0){
         ep->q[ep->w % ep->size] = *m;
         ep->w++;
         wakeup(&ep->r);
+        ok = 0;
     }
     release(&ep->lock);
+    return ok;
 }
 
 int
@@ -48,11 +78,16 @@ endpoint_recv(struct endpoint *ep, zipc_msg_t *m)
     while(ep->q && ep->r == ep->w){
         sleep(&ep->r, &ep->lock);
     }
-    if(!ep->q){
+    if(!ep->q || !ep->type){
         release(&ep->lock);
         return -1;
     }
-    *m = ep->q[ep->r % ep->size];
+    zipc_msg_t tmp = ep->q[ep->r % ep->size];
+    if(check_msg(ep, &tmp) < 0){
+        release(&ep->lock);
+        return -1;
+    }
+    *m = tmp;
     ep->r++;
     release(&ep->lock);
     return 0;
@@ -64,8 +99,7 @@ sys_endpoint_send(void)
     zipc_msg_t *umsg;
     if(argptr(0, (void*)&umsg, sizeof(*umsg)) < 0)
         return -1;
-    endpoint_send(&global_ep, umsg);
-    return 0;
+    return endpoint_send(&global_ep, umsg);
 }
 
 int
@@ -75,7 +109,8 @@ sys_endpoint_recv(void)
     zipc_msg_t m;
     if(argptr(0, (void*)&udst, sizeof(*udst)) < 0)
         return -1;
-    endpoint_recv(&global_ep, &m);
+    if(endpoint_recv(&global_ep, &m) < 0)
+        return -1;
     memmove(udst, &m, sizeof(m));
     return 0;
 }

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -5,8 +5,17 @@ chan_t *
 chan_create(size_t msg_size)
 {
     chan_t *c = malloc(sizeof(chan_t));
-    if(c)
+    if(c){
         c->msg_size = msg_size;
+        size_t n = msg_size;
+        c->desc.w0_sz = n > 8 ? 8 : n;
+        n = n > 8 ? n - 8 : 0;
+        c->desc.w1_sz = n > 8 ? 8 : n;
+        n = n > 8 ? n - 8 : 0;
+        c->desc.w2_sz = n > 8 ? 8 : n;
+        n = n > 8 ? n - 8 : 0;
+        c->desc.w3_sz = n > 8 ? 8 : n;
+    }
     return c;
 }
 
@@ -17,13 +26,13 @@ chan_destroy(chan_t *c)
 }
 
 int
-endpoint_send(chan_t *c, exo_cap dest, const void *msg)
+chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg)
 {
     return cap_send(dest, msg, c->msg_size);
 }
 
 int
-endpoint_recv(chan_t *c, exo_cap src, void *msg)
+chan_endpoint_recv(chan_t *c, exo_cap src, void *msg)
 {
     return cap_recv(src, msg, c->msg_size);
 }


### PR DESCRIPTION
## Summary
- add `msg_type_desc` to describe message field sizes
- track descriptor inside endpoint structure
- validate messages in endpoint_send/recv
- compute descriptors when creating channels
- rename channel helpers to avoid syscall name clash

## Testing
- `make` *(fails: `missing separator` in Makefile)*