### PR TITLE
Add typed endpoint checks

### DIFF
--- a/ipc.h
+++ b/ipc.h
@@ -25,6 +25,10 @@ typedef struct msg_type_desc {
   size_t msg_size; // total message size in bytes
 } msg_type_desc;
 
+static inline size_t msg_desc_size(const struct msg_type_desc *d) {
+  return d ? d->msg_size : sizeof(zipc_msg_t);
+}
+
 static inline int zipc_call(zipc_msg_t *m) {
   register uint64_t rdi __asm("rdi") = m->badge;
   register uint64_t rsi __asm("rsi") = m->w0;

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 export DEBIAN_FRONTEND=noninteractive
-apt_pin_install() {
-  local pkg="$1"
-  local ver
-  ver=$(apt-cache show "$pkg" 2>/dev/null | awk '/^Version:/{print $2; exit}')
+
+#— helper to pin to the repo’s exact version if it exists
+apt_pin_install(){
+  pkg="$1"
+  ver=$(apt-cache show "$pkg" 2>/dev/null \
+        | awk '/^Version:/{print $2; exit}')
   if [ -n "$ver" ]; then
     apt-get install -y "${pkg}=${ver}"
   else
@@ -13,15 +14,14 @@ apt_pin_install() {
   fi
 }
 
-
+#— enable foreign architectures for cross-compilation
 for arch in i386 armel armhf arm64 riscv64 powerpc ppc64el ia64; do
   dpkg --add-architecture "$arch"
 done
 
 apt-get update -y
 
-# core build tools, formatters, analysis, science libs
-
+#— core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format uncrustify astyle editorconfig pre-commit \
@@ -35,8 +35,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-
-# Python & deep-learning / MLOps
+#— Python & deep-learning / MLOps
 for pkg in \
   python3 python3-pip python3-dev python3-venv python3-wheel \
   python3-numpy python3-scipy python3-pandas \
@@ -50,8 +49,7 @@ pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 
-
-# QEMU emulation for foreign binaries
+#— QEMU emulation for foreign binaries
 for pkg in \
   qemu-user-static \
   qemu-system-x86 qemu-system-arm qemu-system-aarch64 \
@@ -59,7 +57,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-# multi-arch cross-compilers
+#— multi-arch cross-compilers
 for pkg in \
   bcc bin86 elks-libc \
   gcc-ia64-linux-gnu g++-ia64-linux-gnu \
@@ -81,7 +79,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-
+#— high-level language runtimes and tools
 for pkg in \
   golang-go nodejs npm typescript \
   rustc cargo clippy rustfmt \
@@ -98,20 +96,21 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
+#— GUI & desktop-dev frameworks
 for pkg in \
   libqt5-dev qtcreator libqt6-dev \
   libgtk1.2-dev libgtk2.0-dev libgtk-3-dev libgtk-4-dev \
-  libfltk-dev xorg-dev libx11-dev libxext-dev \
+  libfltk1.3-dev xorg-dev libx11-dev libxext-dev \
   libmotif-dev openmotif cde \
   xfce4-dev-tools libxfce4ui-2-dev lxde-core lxqt-dev-tools \
   libefl-dev libeina-dev \
-  libwxgtk-dev libwxgtk-gtk3-dev \
+  libwxgtk3.0-dev libwxgtk3.0-gtk3-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev \
   libglfw3-dev libglew-dev; do
   apt_pin_install "$pkg"
 done
 
-# containers, virtualization, HPC, debug
+#— containers, virtualization, HPC, debug
 for pkg in \
   docker.io podman buildah virt-manager libvirt-daemon-system qemu-kvm \
   gdb lldb perf gcovr lcov bcc-tools bpftrace \
@@ -119,22 +118,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-IA16_VER=$(curl -fsSL https://api.github.com/repos/tkchia/gcc-ia16/releases/latest | awk -F\" '/tag_name/{print $4; exit}')
-curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" | tar -Jx -C /opt
-echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
-export PATH=/opt/ia16-elf-gcc/bin:$PATH
-
-PROTO_VERSION=25.1
-curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
-unzip -d /usr/local /tmp/protoc.zip
-rm /tmp/protoc.zip
-
-command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
-
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-
-# IA-16 (8086/286) cross-compiler
+#— IA-16 (8086/286) cross-compiler
 IA16_VER=$(curl -fsSL https://api.github.com/repos/tkchia/gcc-ia16/releases/latest \
            | awk -F\" '/tag_name/{print $4; exit}')
 curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" \
@@ -142,19 +126,18 @@ curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia1
 echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
 export PATH=/opt/ia16-elf-gcc/bin:$PATH
 
-# protoc installer (pinned)
+#— protoc installer (pinned)
 PROTO_VERSION=25.1
 curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" \
   -o /tmp/protoc.zip
 unzip -d /usr/local /tmp/protoc.zip
 rm /tmp/protoc.zip
 
-# gmake alias
+#— gmake alias
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
 
-# clean up
+#— clean up
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-
 
 exit 0

--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -6,11 +6,7 @@
 
 static struct endpoint global_ep;
 
-static inline size_t
-msg_desc_size(const struct msg_type_desc *d)
-{
-    return d ? d->msg_size : sizeof(zipc_msg_t);
-}
+
 
 void
 endpoint_init(struct endpoint *ep)

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -8,7 +8,7 @@ chan_create(const struct msg_type_desc *desc)
     chan_t *c = malloc(sizeof(chan_t));
     if(c){
         c->desc = desc;
-        c->msg_size = desc ? desc->msg_size : 0;
+        c->msg_size = msg_desc_size(desc);
     }
     return c;
 }


### PR DESCRIPTION
## Summary
- script: install full build deps with apt pinning
- provide helper `msg_desc_size` in ipc header
- use typed message size when creating channels
- rely on common descriptor helper in endpoint logic

## Testing
- `make kernel/entry.o` *(fails: Makefile:42: missing separator)*