### PR TITLE
Add CPU gas accounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ LIBOS_DIR := libos
        $(KERNEL_DIR)/fastipc.o\
        $(KERNEL_DIR)/endpoint.o\
        $(KERNEL_DIR)/dag_sched.o
-       $(KERNEL_DIR)/cap.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o

--- a/defs.h
+++ b/defs.h
@@ -163,7 +163,6 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 struct proc*    pctr_lookup(uint);
-int             cap_verify(uint);
 struct proc*    allocproc(void);
 
 
@@ -266,7 +265,6 @@ void            fastipc_send(zipc_msg_t *);
 int             sys_ipc_fast(void);
 void            endpoint_send(struct endpoint *, zipc_msg_t *);
 int             endpoint_recv(struct endpoint *, zipc_msg_t *);
-void            dag_sched_init(void);
 void            dag_node_init(struct dag_node *, exo_cap);
 void            dag_node_add_dep(struct dag_node *, struct dag_node *);
 void            dag_sched_submit(struct dag_node *);

--- a/proc.h
+++ b/proc.h
@@ -85,37 +85,31 @@ enum procstate { UNUSED, EMBRYO, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 // Per-process state
 struct proc {
   size_t sz;                     // Size of process memory (bytes)
-  pde_t* pgdir;                // Page table
-  char *kstack;                // Bottom of kernel stack for this process
-  enum procstate state;        // Process state
-  int pid;                     // Process ID
-  struct proc *parent;         // Parent process
-  struct trapframe *tf;        // Trap frame for current syscall
-  context_t *context;          // swtch() here to run process
-  void (*timer_upcall)(void);  // user-mode timer interrupt handler
-  void *chan;                  // If non-zero, sleeping on chan
-  int killed;                  // If non-zero, have been killed
-  struct file *ofile[NOFILE];  // Open files
-  struct inode *cwd;           // Current directory
-  char name[16];               // Process name (debugging)
-  uint pctr_cap;               // Capability for exo_pctr_transfer
-  volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
-  uint64 gas_remaining;        // Remaining CPU budget
-};
-
- int preferred_node;          // NUMA allocation preference
+  pde_t* pgdir;                  // Page table
+  char *kstack;                  // Bottom of kernel stack for this process
+  enum procstate state;          // Process state
+  int pid;                       // Process ID
+  struct proc *parent;           // Parent process
+  struct trapframe *tf;          // Trap frame for current syscall
+  context_t *context;            // swtch() here to run process
+  void (*timer_upcall)(void);    // user-mode timer interrupt handler
+  void *chan;                    // If non-zero, sleeping on chan
+  int killed;                    // If non-zero, have been killed
+  struct file *ofile[NOFILE];    // Open files
+  struct inode *cwd;             // Current directory
+  char name[16];                 // Process name (debugging)
+  uint pctr_cap;                 // Capability for exo_pctr_transfer
+  volatile uint pctr_signal;     // Signal counter for exo_pctr_transfer
+  uint64 gas_remaining;          // Remaining CPU budget
+  int preferred_node;            // NUMA allocation preference
+  int out_of_gas;                // Flag set when gas runs out
 };
 
 // Ensure scheduler relies on fixed struct proc size
-#if defined(__x86_64__)
-_Static_assert(sizeof(struct proc) == 240, "struct proc size incorrect");
-#elif !defined(__aarch64__)
-_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
-#ifdef __x86_64__
-_Static_assert(sizeof(struct proc) == 248, "struct proc size incorrect");
+#if defined(__x86_64__) || defined(__aarch64__)
+_Static_assert(sizeof(struct proc) == 256, "struct proc size incorrect");
 #else
-_Static_assert(sizeof(struct proc) == 140, "struct proc size incorrect");
-
+_Static_assert(sizeof(struct proc) == 152, "struct proc size incorrect");
 #endif
 
 

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -144,6 +144,7 @@ found:
   p->pctr_signal = 0;
   p->gas_remaining = 0;
   p->preferred_node = 0;
+  p->out_of_gas = 0;
 
   pctr_insert(p);
 
@@ -281,6 +282,7 @@ fork(void)
       np->ofile[i] = filedup(curproc->ofile[i]);
   np->cwd = idup(curproc->cwd);
   np->preferred_node = curproc->preferred_node;
+  np->out_of_gas = 0;
 
   safestrcpy(np->name, curproc->name, sizeof(curproc->name));
 
@@ -411,7 +413,7 @@ scheduler(void)
     acquire(&ptable.lock);
     found = 0;
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
-      if(p->state != RUNNABLE || p->gas_remaining == 0)
+      if(p->state != RUNNABLE || p->out_of_gas)
         continue;
       found = 1;
 

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -300,6 +300,8 @@ int sys_set_gas(void) {
   if (argint(0, (int *)&amount) < 0)
     return -1;
   myproc()->gas_remaining = amount;
+  if (amount > 0)
+    myproc()->out_of_gas = 0;
   return 0;
 }
 

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -55,6 +55,7 @@ void trap(struct trapframe *tf) {
       if (myproc()->gas_remaining > 0)
         myproc()->gas_remaining--;
       if (myproc()->gas_remaining == 0) {
+        myproc()->out_of_gas = 1;
         lapiceoi();
         yield();
         break;

--- a/src-uland/libos/sched.c
+++ b/src-uland/libos/sched.c
@@ -17,9 +17,13 @@ static void sched_tick(void) {
         return;
     if(get_gas() > 0)
         return;
-    cur = (cur + 1) % nprocs;
-    set_gas(GAS_SLICE);
-    cap_yield_to_cap(runq[cur]);
+    for(int i = 0; i < nprocs; i++) {
+        cur = (cur + 1) % nprocs;
+        set_gas(GAS_SLICE);
+        cap_yield_to_cap(runq[cur]);
+        if(get_gas() > 0)
+            break;
+    }
 }
 
 void sched_install_timer(void) {


### PR DESCRIPTION
## Summary
- add `gas_remaining` and `out_of_gas` tracking to `struct proc`
- export setters/getters via syscalls
- decrement gas on each timer tick and preempt when exhausted
- skip processes that are out of gas in the scheduler
- update user‐level scheduler to cycle through tasks when gas is depleted
- fix Makefile and header declarations

## Testing
- `make` *(fails: incompatible type for argument 1 of `cap_verify`)*