### PR TITLE
Implement gas budget counter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,12 +203,11 @@ LIBOS_OBJS = \
        usys.o \
         $(ULAND_DIR)/printf.o \
         $(ULAND_DIR)/umalloc.o \
-       $(KERNEL_DIR)/swtch.o \
+        $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
-        $(ULAND_DIR)/math_core.o
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o
+        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o
 

--- a/proc.h
+++ b/proc.h
@@ -83,13 +83,14 @@ struct proc {
   char name[16];               // Process name (debugging)
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
+  uint64 gas_remaining;        // Remaining CPU budget in ticks
 };
 
 // Ensure scheduler relies on fixed struct proc size
 #ifdef __x86_64__
-_Static_assert(sizeof(struct proc) == 240, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 248, "struct proc size incorrect");
 #else
-_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 144, "struct proc size incorrect");
 #endif
 
 

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -142,6 +142,7 @@ found:
   p->pid = nextpid++;
   p->pctr_cap = nextpctr_cap++;
   p->pctr_signal = 0;
+  p->gas_remaining = 0;
   pctr_insert(p);
 
   release(&ptable.lock);
@@ -462,6 +463,18 @@ yield(void)
   myproc()->state = RUNNABLE;
   sched();
   release(&ptable.lock);
+}
+
+// Called from timer interrupt each tick to charge running process.
+void
+proc_tick(void)
+{
+  struct proc *p = myproc();
+  if(p && p->state == RUNNING && p->gas_remaining > 0){
+    p->gas_remaining--;
+    if(p->gas_remaining == 0)
+      yield();
+  }
 }
 
 // A fork child's very first scheduling by scheduler()

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -160,6 +160,8 @@ extern int sys_exo_recv(void);
 extern int sys_endpoint_send(void);
 extern int sys_endpoint_recv(void);
 extern int sys_proc_alloc(void);
+extern int sys_set_gas(void);
+extern int sys_get_gas(void);
 extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
@@ -199,6 +201,8 @@ static int (*syscalls[])(void) = {
     [SYS_endpoint_send] sys_endpoint_send,
     [SYS_endpoint_recv] sys_endpoint_recv,
     [SYS_proc_alloc] sys_proc_alloc,
+    [SYS_set_gas] sys_set_gas,
+    [SYS_get_gas] sys_get_gas,
     [SYS_ipc_fast] sys_ipc_fast,
 };
 

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -254,4 +254,16 @@ int sys_proc_alloc(void) {
   return cap.pa;
 }
 
+int sys_set_gas(void) {
+  int amount;
+  if (argint(0, &amount) < 0)
+    return -1;
+  myproc()->gas_remaining = amount;
+  return 0;
+}
+
+int sys_get_gas(void) {
+  return myproc()->gas_remaining;
+}
+
 // Provided by fastipc.c

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -8,6 +8,8 @@
 #include "types.h"
 #include "x86.h"
 
+extern void proc_tick(void);
+
 // Interrupt descriptor table (shared by all CPUs).
 struct gatedesc idt[256];
 extern uint vectors[]; // in vectors.S: array of 256 entry pointers
@@ -52,6 +54,7 @@ void trap(struct trapframe *tf) {
       release(&tickslock);
     }
     lapiceoi();
+    proc_tick();
     if (myproc() && myproc()->timer_upcall && (tf->cs & 3) == DPL_USER) {
 #ifndef __x86_64__
       tf->esp -= 4;

--- a/src-uland/libos/sched.c
+++ b/src-uland/libos/sched.c
@@ -1,6 +1,8 @@
 #include "libos/sched.h"
 
 #define MAX_PROCS 64
+#define QUANTUM    5
+#define GAS_INFINITY 0x7fffffff
 
 static exo_cap runq[MAX_PROCS];
 static int nprocs = 0;
@@ -14,8 +16,12 @@ void sched_add(exo_cap cap) {
 static void sched_tick(void) {
     if(nprocs == 0)
         return;
+    set_gas(QUANTUM);
     cur = (cur + 1) % nprocs;
     cap_yield_to_cap(runq[cur]);
+    if(get_gas() == 0)
+        ; // timeslice exhausted
+    set_gas(GAS_INFINITY);
 }
 
 void sched_install_timer(void) {
@@ -24,6 +30,7 @@ void sched_install_timer(void) {
 
 void sched_run(void) {
     sched_install_timer();
+    set_gas(GAS_INFINITY);
     while(1)
         sched_tick();
 }

--- a/syscall.h
+++ b/syscall.h
@@ -28,13 +28,16 @@
 #define SYS_exo_unbind_page 25
 #define SYS_exo_alloc_block 26
 #define SYS_exo_bind_block 27
-#define SYS_exo_yield_to 28
-#define SYS_exo_read_disk 29
-#define SYS_exo_write_disk 30
-#define SYS_exo_send 31
-#define SYS_exo_recv 32
-#define SYS_endpoint_send 33
-#define SYS_endpoint_recv 34
-#define SYS_proc_alloc 35
+#define SYS_exo_flush_block 28
+#define SYS_exo_yield_to 29
+#define SYS_exo_read_disk 30
+#define SYS_exo_write_disk 31
+#define SYS_exo_send 32
+#define SYS_exo_recv 33
+#define SYS_endpoint_send 34
+#define SYS_endpoint_recv 35
+#define SYS_proc_alloc 36
+#define SYS_set_gas 37
+#define SYS_get_gas 38
 #define SYS_ipc_fast 0x30
 

--- a/user.h
+++ b/user.h
@@ -47,6 +47,8 @@ int endpoint_recv(zipc_msg_t *msg);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 exo_cap proc_alloc(void);
+int set_gas(int amount);
+int get_gas(void);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/usys.S
+++ b/usys.S
@@ -69,5 +69,7 @@ SYSCALL(exo_recv)
 SYSCALL(endpoint_send)
 SYSCALL(endpoint_recv)
 SYSCALL(proc_alloc)
+SYSCALL(set_gas)
+SYSCALL(get_gas)
 
 


### PR DESCRIPTION
## Summary
- add `gas_remaining` field in `struct proc`
- introduce `set_gas` and `get_gas` syscalls
- charge gas on each timer tick and preempt when it runs out
- wire new syscalls into syscall tables and user stubs
- update userland scheduler to use gas accounting

## Testing
- `make`