### PR TITLE
Remove duplicate capability prototypes

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -2,7 +2,6 @@
 #define EXO_H
 #include "types.h"
 
-
 typedef struct hash256 {
   uint64 parts[4];
 } hash256_t;
@@ -13,7 +12,6 @@ typedef struct exo_cap {
   uint rights;
   uint owner;
   hash256_t auth_tag;
-
 } exo_cap;
 
 typedef struct exo_blockcap {
@@ -25,8 +23,6 @@ typedef struct exo_blockcap {
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
-exo_cap cap_new(uint id, uint rights, uint owner);
-int cap_verify(exo_cap c);
 exo_cap cap_new(uint id, uint rights, uint owner);
 int cap_verify(exo_cap c);
 


### PR DESCRIPTION
## Summary
- clean up `exo.h`
  - drop duplicate declarations of `cap_new` and `cap_verify`
  - collapse stray blank lines

## Testing
- `make` *(fails: `EPERM` undeclared)*