### PR TITLE
Fix caplib wrapper functions

### DIFF
--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -8,11 +8,6 @@ exo_cap cap_alloc_page(void) {
   return cap;
 }
 
-  exo_cap c;
-  exo_alloc_page(&c);
-  return c;
-}
-
 int cap_unbind_page(exo_cap cap) { return exo_unbind_page(&cap); }
 
 int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
@@ -35,7 +30,7 @@ void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);
 }
 
-int cap_yield_to_cap(exo_cap target) { return exo_yield_to(&target); }
+int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
 
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n) {
   return exo_read_disk(cap, dst, off, n);
@@ -46,11 +41,11 @@ int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n) {
 }
 
 int cap_send(exo_cap dest, const void *buf, uint64 len) {
-  return exo_send(&dest, buf, len);
+  return exo_send(dest, buf, len);
 }
 
 int cap_recv(exo_cap src, void *buf, uint64 len) {
-  return exo_recv(&src, buf, len);
+  return exo_recv(src, buf, len);
 }
 
 int cap_ipc_echo_demo(void) {


### PR DESCRIPTION
## Summary
- remove duplicate block in `cap_alloc_page`
- pass capabilities by value in wrapper functions to match system call prototypes
- keep newline at file end

## Testing
- `make -j4` *(fails: EPERM undeclared etc.)*