### PR TITLE
Fix capability hashing

### DIFF
--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -1,20 +1,9 @@
 #include "types.h"
 #include "exo.h"
 #include "defs.h"
+#include <string.h>
 
-static uint cap_secret = 0xdeadbeef;
-
-static void
-gen_hash(uint id, uint rights, uint owner, hash256_t *out)
-{
-    for(int i = 0; i < 32; i++)
-        out->bytes[i] = (uchar)(cap_secret ^ id ^ rights ^ owner ^ i);
-}
-
-exo_cap
-cap_new(uint id, uint rights, uint owner)
-{
-
+/* Secret key used for capability HMAC */
 static const uint8_t cap_secret[32] = {
     0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
     0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
@@ -22,36 +11,48 @@ static const uint8_t cap_secret[32] = {
     0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
 };
 
-static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
+/* 64-bit FNV-1a hash used by the HMAC implementation */
+static uint64
+fnv64(const uint8_t *data, size_t len, uint64 seed)
+{
     const uint64 prime = 1099511628211ULL;
     uint64 h = seed;
-    for(size_t i=0;i<len;i++) {
+    for(size_t i = 0; i < len; i++) {
         h ^= data[i];
         h *= prime;
     }
     return h;
 }
 
-static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
+/* Hash data into four 64-bit words */
+static void
+hash256(const uint8_t *data, size_t len, hash256_t *out)
+{
     const uint64 basis = 14695981039346656037ULL;
-    for(int i=0;i<4;i++)
+    for(int i = 0; i < 4; i++)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 
-static void hmac_hash(const void *msg, size_t len, hash256_t *out) {
-    // simple HMAC-like: hash(secret || msg)
-    uint8_t buf[sizeof(cap_secret)+len];
+/* Derive the authentication tag for a capability. */
+static void
+compute_tag(uint id, uint rights, uint owner, hash256_t *out)
+{
+    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
+
     memmove(buf, cap_secret, sizeof(cap_secret));
-    memmove(buf+sizeof(cap_secret), msg, len);
+    memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
     hash256(buf, sizeof(buf), out);
 }
 
-exo_cap cap_new(uint id, uint rights, uint owner) {
+exo_cap
+cap_new(uint id, uint rights, uint owner)
+{
     exo_cap c;
     c.id = id;
     c.rights = rights;
     c.owner = owner;
-    gen_hash(id, rights, owner, &c.auth_tag);
+    compute_tag(id, rights, owner, &c.auth_tag);
     return c;
 }
 
@@ -59,9 +60,7 @@ int
 cap_verify(exo_cap c)
 {
     hash256_t h;
-    gen_hash(c.id, c.rights, c.owner, &h);
+    compute_tag(c.id, c.rights, c.owner, &h);
     return memcmp(h.bytes, c.auth_tag.bytes, sizeof(h.bytes)) == 0;
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
-    hmac_hash(&tmp, sizeof(tmp), &c.auth_tag);
-    return c;
 }
+

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -445,12 +445,6 @@ exo_alloc_page(void)
   char *mem = kalloc();
   uint pa = mem ? V2P(mem) : 0;
   return cap_new(pa, 0, myproc()->pid);
-  exo_cap cap;
-  cap.pa = mem ? V2P(mem) : 0;
-  cap.owner = myproc()->pid;
-  return cap;
-  uint id = mem ? V2P(mem) : 0;
-  return cap_new(id, 0, myproc()->pid);
 }
 
 // Remove any mappings to the page referenced by cap and free it.


### PR DESCRIPTION
## Summary
- implement a single HMAC-based capability hashing scheme
- clean dead code in `exo_alloc_page`

## Testing
- `make -k` *(fails: many unrelated compilation errors)*