### PR TITLE
Fix truncated capability demos

### DIFF
--- a/caplib.h
+++ b/caplib.h
@@ -17,8 +17,4 @@ void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
-int cap_send(exo_cap dest, const void *buf, uint64 len);
-int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_ipc_echo_demo(void);
-int cap_send(exo_cap dest, const void *buf, uint64 len);
-int cap_recv(exo_cap src, void *buf, uint64 len);

--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -7,46 +7,13 @@ static uint cap_secret = 0xdeadbeef;
 static void
 gen_hash(uint id, uint rights, uint owner, hash256_t *out)
 {
-    for(int i = 0; i < 32; i++)
+    for (int i = 0; i < 32; i++)
         out->bytes[i] = (uchar)(cap_secret ^ id ^ rights ^ owner ^ i);
 }
 
 exo_cap
 cap_new(uint id, uint rights, uint owner)
 {
-
-static const uint8_t cap_secret[32] = {
-    0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
-    0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
-    0x55,0xaa,0x55,0xaa,0x00,0x11,0x22,0x33,
-    0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
-};
-
-static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
-    const uint64 prime = 1099511628211ULL;
-    uint64 h = seed;
-    for(size_t i=0;i<len;i++) {
-        h ^= data[i];
-        h *= prime;
-    }
-    return h;
-}
-
-static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
-    const uint64 basis = 14695981039346656037ULL;
-    for(int i=0;i<4;i++)
-        out->parts[i] = fnv64(data, len, basis + i);
-}
-
-static void hmac_hash(const void *msg, size_t len, hash256_t *out) {
-    // simple HMAC-like: hash(secret || msg)
-    uint8_t buf[sizeof(cap_secret)+len];
-    memmove(buf, cap_secret, sizeof(cap_secret));
-    memmove(buf+sizeof(cap_secret), msg, len);
-    hash256(buf, sizeof(buf), out);
-}
-
-exo_cap cap_new(uint id, uint rights, uint owner) {
     exo_cap c;
     c.id = id;
     c.rights = rights;
@@ -61,7 +28,4 @@ cap_verify(exo_cap c)
     hash256_t h;
     gen_hash(c.id, c.rights, c.owner, &h);
     return memcmp(h.bytes, c.auth_tag.bytes, sizeof(h.bytes)) == 0;
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
-    hmac_hash(&tmp, sizeof(tmp), &c.auth_tag);
-    return c;
 }

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -8,11 +8,6 @@ exo_cap cap_alloc_page(void) {
   return cap;
 }
 
-  exo_cap c;
-  exo_alloc_page(&c);
-  return c;
-}
-
 int cap_unbind_page(exo_cap cap) { return exo_unbind_page(&cap); }
 
 int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {

--- a/src-uland/sh.c
+++ b/src-uland/sh.c
@@ -206,9 +206,8 @@ fork1(void)
 }
 
 static int __attribute__((unused))
-isbuiltin(struct cmd *cmd) {
-static int isbuiltin(struct cmd *cmd) __attribute__((unused));
-static int isbuiltin(struct cmd *cmd) {
+isbuiltin(struct cmd *cmd)
+{
 
   struct execcmd *ecmd;
 

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -2,19 +2,11 @@
 #include "types.h"
 #include "user.h"
 
-// Stub function since kernel support is unavailable
-int exo_yield_to(exo_cap *target) {
-  printf(1, "exo_yield_to called with cap %u\n", target->id);
-
-// Stub function renamed to avoid clashing with syscall stub
-int exo_yield_to_demo(exo_cap target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target.pa);
-// Stub function since kernel support is unavailable
-
-int exo_yield_to(exo_cap *target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target->id);
-
-  return 0;
+// Simple user-level demonstration for exo_yield_to
+int exo_yield_to_demo(exo_cap target)
+{
+    printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
+    return 0;
 }
 
 // Simplified STREAMS API stubs
@@ -22,13 +14,13 @@ void streams_stop(void) { printf(1, "streams_stop called\n"); }
 
 void streams_yield(void) { printf(1, "streams_yield called\n"); }
 
-int main(int argc, char *argv[]) {
-  exo_cap cap = {0, 0};
-  printf(1, "STREAMS/exo yield demo\n");
-  streams_stop();
-  exo_yield_to_demo(cap);
-  demo_yield_to(cap);
-  exo_yield_to(&cap);
-  streams_yield();
-  exit();
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    exo_cap cap = {0, 0};
+    printf(1, "STREAMS/exo yield demo\n");
+    streams_stop();
+    exo_yield_to_demo(cap);
+    streams_yield();
+    exit();
 }


### PR DESCRIPTION
## Summary
- remove corrupted declarations in `caplib.h`
- clean up capability implementations in kernel and userspace
- rewrite userland exo stream demo
- fix `isbuiltin()` definition in shell

## Testing
- `make -j2` *(fails: `EPERM` undeclared)*