### PR TITLE
Ensure cross-compiler packages and setup instructions

### DIFF
--- a/README
+++ b/README
@@ -55,7 +55,13 @@ Then run "make TOOLPREFIX=i386-jos-elf-". Now install the QEMU PC
 simulator and run "make qemu".
 A helper script, `setup.sh`, installs cross-compilers, build dependencies,
 QEMU packages, and additional development tools.  Run it once before
-building to ensure all prerequisites are available.
+building to ensure all prerequisites are available.  From the top-level
+directory simply execute::
+
+    sudo ./setup.sh
+
+This only needs to be done after cloning the repository or when
+dependencies change.
 
 Experimental support for building with the C23 standard and for
 cross-compiling a 64-bit version is available. Set

--- a/setup.sh
+++ b/setup.sh
@@ -60,6 +60,9 @@ done
 #— multi-arch cross-compilers
 for pkg in \
   bcc bin86 elks-libc \
+  gcc-multilib g++-multilib \
+  binutils-i686-linux-gnu binutils-x86-64-linux-gnu \
+  gcc-x86-64-linux-gnu g++-x86-64-linux-gnu \
   gcc-ia64-linux-gnu g++-ia64-linux-gnu \
   gcc-i686-linux-gnu g++-i686-linux-gnu \
   gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \


### PR DESCRIPTION
## Summary
- document running `setup.sh`
- add missing x86 cross packages to setup script

## Testing
- `bash -n setup.sh`
- `make --dry-run | head`