### PR TITLE
Clean demo sources and stub kernel deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,6 @@ $(KERNEL_DIR)/vectors.S: vectors.pl
 	./vectors.pl > $@
 
 LIBOS_OBJS = \
-        $(ULAND_DIR)/usys.o \
         $(ULAND_DIR)/ulib.o \
         usys.o \
         $(ULAND_DIR)/printf.o \

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -4,6 +4,8 @@
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
+#include <errno.h>
+#include "include/exokernel.h"
 
 #define IPC_BUFSZ 64
 

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -18,6 +18,8 @@
 #include "spinlock.h"
 #include "sleeplock.h"
 #include "fs.h"
+#include <errno.h>
+#include "include/exokernel.h"
 #include "buf.h"
 #include "file.h"
 #include "exo.h"

--- a/src-kernel/kernel/exo_disk.c
+++ b/src-kernel/kernel/exo_disk.c
@@ -4,6 +4,8 @@
 #include "sleeplock.h"
 #include "buf.h"
 #include "kernel/exo_disk.h"
+#include <errno.h>
+#include "include/exokernel.h"
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 

--- a/src-uland/user/dag_demo.c
+++ b/src-uland/user/dag_demo.c
@@ -1,12 +1,22 @@
-#include "caplib.h"
-#include "types.h"
-#include "user.h"
-#include "dag.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 
-// Stub exo_yield_to since kernel support is unavailable
-int exo_yield_to(exo_cap target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target.pa);
-  return 0;
+typedef struct exo_cap { uint32_t pa; } exo_cap;
+
+struct dag_node { int pending; };
+
+static void dag_node_init(struct dag_node *n, exo_cap ctx) {
+  (void)ctx; n->pending = 0;
+}
+static void dag_node_add_dep(struct dag_node *parent, struct dag_node *child) {
+  (void)parent; (void)child;
+}
+static void dag_sched_submit(struct dag_node *node) {
+  (void)node; printf("dag_sched_submit\n");
+}
+static void exo_stream_yield(void) {
+  printf("exo_stream_yield called\n");
 }
 
 static struct dag_node a, b, c;
@@ -24,8 +34,9 @@ static void setup(void) {
 }
 
 int main(int argc, char *argv[]) {
-  printf(1, "DAG scheduler demo\n");
+  (void)argc; (void)argv;
+  printf("DAG scheduler demo\n");
   setup();
   exo_stream_yield();
-  exit();
+  return 0;
 }

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -1,34 +1,32 @@
-#include "caplib.h"
-#include "types.h"
-#include "user.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 
-// Stub function since kernel support is unavailable
-int exo_yield_to(exo_cap *target) {
-  printf(1, "exo_yield_to called with cap %u\n", target->id);
+typedef struct exo_cap {
+  uint32_t pa;
+  uint32_t id;
+} exo_cap;
 
-// Stub function renamed to avoid clashing with syscall stub
-int exo_yield_to_demo(exo_cap target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target.pa);
-// Stub function since kernel support is unavailable
-
-int exo_yield_to(exo_cap *target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target->id);
-
+// Minimal stub implementations used when kernel support is absent.
+static int exo_yield_to_demo(exo_cap target) {
+  printf("exo_yield_to called with cap %p\n", (void *)target.pa);
   return 0;
 }
 
-// Simplified STREAMS API stubs
-void streams_stop(void) { printf(1, "streams_stop called\n"); }
+int exo_yield_to(exo_cap *target) {
+  printf("exo_yield_to called with cap %u\n", target->id);
+  return 0;
+}
 
-void streams_yield(void) { printf(1, "streams_yield called\n"); }
+void streams_stop(void) { printf("streams_stop called\n"); }
+void streams_yield(void) { printf("streams_yield called\n"); }
 
 int main(int argc, char *argv[]) {
   exo_cap cap = {0, 0};
-  printf(1, "STREAMS/exo yield demo\n");
+  printf("STREAMS/exo yield demo\n");
   streams_stop();
   exo_yield_to_demo(cap);
-  demo_yield_to(cap);
   exo_yield_to(&cap);
   streams_yield();
-  exit();
+  return 0;
 }


### PR DESCRIPTION
## Summary
- avoid unused usys object dependency
- add errno/exokernel headers to kernel modules
- simplify exo_stream_demo and dag_demo with stub implementations

## Testing
- `gcc src-uland/user/exo_stream_demo.c -o exo_stream_demo`
- `./exo_stream_demo`
- `gcc src-uland/user/dag_demo.c -o dag_demo`
- `./dag_demo`
