### PR TITLE
Cleanup demos and headers

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -21,9 +21,11 @@ typedef struct exo_blockcap {
   uint owner;
 } exo_blockcap;
 
+#ifdef EXO_KERNEL
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap c);
 exo_cap cap_new(uint id, uint rights, uint owner);
 int cap_verify(exo_cap c);
+#endif
 
 #endif // EXO_H

--- a/include/exokernel.h
+++ b/include/exokernel.h
@@ -21,6 +21,7 @@ static inline int cap_has_rights(uint rights, uint need)
  * enforces no policy on queue sizes or scheduling.
  */
 
+#ifndef EXO_KERNEL
 /* Allocate a physical page and store a capability referencing it in *cap.
  * The page is not mapped into the caller's address space.  Returns 0 on
  * success.
@@ -60,6 +61,7 @@ int exo_recv(exo_cap *src, void *buf, uint64 len);
 /* Read or write arbitrary byte ranges using a block capability. */
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
+#endif /* EXO_KERNEL */
 
 /* Enumeration of syscall numbers for the primitives. */
 enum exo_syscall {

--- a/src-headers/errno.h
+++ b/src-headers/errno.h
@@ -1,0 +1,4 @@
+#ifndef XV6_ERRNO_H
+#define XV6_ERRNO_H
+#define EPERM 1
+#endif

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -5,6 +5,7 @@
 #include "spinlock.h"
 #include "types.h"
 #include <errno.h>
+#define EXO_KERNEL
 #include "include/exokernel.h"
 
 #define IPC_BUFSZ 64

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -19,6 +19,7 @@
 #include "sleeplock.h"
 #include "fs.h"
 #include <errno.h>
+#define EXO_KERNEL
 #include "include/exokernel.h"
 #include "buf.h"
 #include "file.h"

--- a/src-kernel/kernel/exo_disk.c
+++ b/src-kernel/kernel/exo_disk.c
@@ -5,6 +5,7 @@
 #include "buf.h"
 #include "kernel/exo_disk.h"
 #include <errno.h>
+#define EXO_KERNEL
 #include "include/exokernel.h"
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -1,31 +1,31 @@
 #include <stdio.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 typedef struct exo_cap {
-  uint32_t pa;
-  uint32_t id;
+    uint32_t pa;
+    uint32_t id;
 } exo_cap;
 
 // Minimal stub implementations used when kernel support is absent.
-static int exo_yield_to_demo(exo_cap target) {
-  printf("exo_yield_to called with cap %p\n", (void *)target.pa);
-  return 0;
+int exo_yield_to(exo_cap *target) {
+    printf("exo_yield_to called with cap %u\n", target->id);
+    return 0;
 }
 
-int exo_yield_to(exo_cap *target) {
-  printf("exo_yield_to called with cap %u\n", target->id);
-  return 0;
-
-// Simple user-level demonstration for exo_yield_to
-int exo_yield_to_demo(exo_cap target)
-{
-    printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
+int exo_yield_to_demo(exo_cap target) {
+    printf("exo_yield_to_demo called with cap %u\n", target.id);
     return 0;
-
 }
 
 void streams_stop(void) { printf("streams_stop called\n"); }
 void streams_yield(void) { printf("streams_yield called\n"); }
 
-
+int main(int argc, char **argv) {
+    (void)argc; (void)argv;
+    exo_cap other = {0, 42};
+    exo_yield_to(&other);
+    exo_yield_to_demo(other);
+    streams_yield();
+    streams_stop();
+    return 0;
+}

--- a/syscall.h
+++ b/syscall.h
@@ -28,17 +28,6 @@
 #define SYS_exo_unbind_page 25
 #define SYS_exo_alloc_block 26
 #define SYS_exo_bind_block 27
-#define SYS_exo_yield_to 28
-#define SYS_exo_read_disk 29
-#define SYS_exo_write_disk 30
-#define SYS_exo_send 31
-#define SYS_exo_recv 32
-#define SYS_endpoint_send 33
-#define SYS_endpoint_recv 34
-#define SYS_proc_alloc 35
-#define SYS_set_gas 36
-#define SYS_get_gas 37
-#define SYS_set_numa_node 36
 #define SYS_exo_flush_block 28
 #define SYS_exo_yield_to 29
 #define SYS_exo_read_disk 30
@@ -48,5 +37,8 @@
 #define SYS_endpoint_send 34
 #define SYS_endpoint_recv 35
 #define SYS_proc_alloc 36
+#define SYS_set_gas 37
+#define SYS_get_gas 38
+#define SYS_set_numa_node 39
 #define SYS_ipc_fast 0x30
 

--- a/user.h
+++ b/user.h
@@ -31,7 +31,6 @@ char *sbrk(int);
 int sleep(int);
 int uptime(void);
 int mappte(void *, void *, int);
-to
 int exo_pctr_transfer(int cap);
 
 int set_timer_upcall(void (*handler)(void));
@@ -39,21 +38,18 @@ int exo_alloc_page(exo_cap *cap);
 int exo_unbind_page(exo_cap *cap);
 int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
-int exo_unbind_page(exo_cap cap);
 int exo_flush_block(exo_blockcap *cap, void *data);
-int exo_yield_to(exo_cap target);
+int exo_yield_to(exo_cap *target);
 int set_gas(uint64 amount);
 int get_gas(void);
-int exo_send(exo_cap dest, const void *buf, uint64 len);
-int exo_recv(exo_cap src, void *buf, uint64 len);
+int exo_send(exo_cap *dest, const void *buf, uint64 len);
+int exo_recv(exo_cap *src, void *buf, uint64 len);
 int endpoint_send(chan_t *c, exo_cap dest, const void *msg);
 int endpoint_recv(chan_t *c, exo_cap src, void *msg);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 int proc_alloc(exo_cap *cap);
-exo_cap proc_alloc(void);
 int set_numa_node(int);
-int proc_alloc(exo_cap *cap);
 
 // ulib.c
 int stat(const char *, struct stat *);


### PR DESCRIPTION
## Summary
- simplify `exo_stream_demo.c` with one main and stub helpers
- ensure DAG demo compiles standalone
- provide a tiny `errno.h` for stubs
- clean up syscall numbers and user headers
- avoid prototype clashes by guarding kernel headers

## Testing
- `gcc -Wall -Wextra -std=c99 src-uland/user/exo_stream_demo.c -o /tmp/exo_stream_demo && /tmp/exo_stream_demo`
- `gcc -Wall -Wextra -std=c99 src-uland/user/dag_demo.c -o /tmp/dag_demo && /tmp/dag_demo`
