### PR TITLE
Fix truncated source fragments

### DIFF
--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -2,15 +2,6 @@
 #include "exo.h"
 #include "defs.h"
 #include <string.h>
-
-static uint cap_secret = 0xdeadbeef;
-
-static void
-gen_hash(uint id, uint rights, uint owner, hash256_t *out)
-{
-    for (int i = 0; i < 32; i++)
-        out->bytes[i] = (uchar)(cap_secret ^ id ^ rights ^ owner ^ i);
-  
 /* Secret key used for capability HMAC */
 static const uint8_t cap_secret[32] = {
     0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -8,21 +8,16 @@ typedef struct exo_cap {
 } exo_cap;
 
 // Minimal stub implementations used when kernel support is absent.
-static int exo_yield_to_demo(exo_cap target) {
-  printf("exo_yield_to called with cap %p\n", (void *)target.pa);
-  return 0;
-}
-
 int exo_yield_to(exo_cap *target) {
   printf("exo_yield_to called with cap %u\n", target->id);
   return 0;
+}
 
 // Simple user-level demonstration for exo_yield_to
 int exo_yield_to_demo(exo_cap target)
 {
     printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
     return 0;
-
 }
 
 void streams_stop(void) { printf("streams_stop called\n"); }


### PR DESCRIPTION
## Summary
- remove leftover cap hashing stub
- clean up exo_stream_demo stub functions

## Testing
- `make` *(fails: errno.h: No such file or directory)*