### PR TITLE
Fix caplib wrappers

### DIFF
--- a/caplib.h
+++ b/caplib.h
@@ -7,7 +7,7 @@ exo_cap cap_alloc_page(void);
 int cap_unbind_page(exo_cap cap);
 int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap);
 int cap_bind_block(exo_blockcap *cap, void *data, int write);
-int cap_flush_block(exo_blockcap *cap, void *data);
+void cap_flush_block(exo_blockcap *cap, void *data);
 int cap_send(exo_cap dest, const void *buf, uint64 len);
 int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_set_timer(void (*handler)(void));

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -3,12 +3,10 @@
 #include "user.h"
 
 exo_cap cap_alloc_page(void) {
-  exo_cap cap;
-  exo_alloc_page(&cap);
-  return cap;
+  return exo_alloc_page();
 }
 
-int cap_unbind_page(exo_cap cap) { return exo_unbind_page(&cap); }
+int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
 
 int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
   return exo_alloc_block(dev, rights, cap);
@@ -18,8 +16,8 @@ int cap_bind_block(exo_blockcap *cap, void *data, int write) {
   return exo_bind_block(cap, data, write);
 }
 
-int cap_flush_block(exo_blockcap *cap, void *data) {
-  return exo_flush_block(cap, data);
+void cap_flush_block(exo_blockcap *cap, void *data) {
+  exo_flush_block(cap, data);
 }
 
 int cap_set_timer(void (*handler)(void)) { return set_timer_upcall(handler); }


### PR DESCRIPTION
## Summary
- remove duplicated block in `cap_alloc_page`
- ensure wrappers use correct prototypes
- expose `cap_flush_block` as a `void` function

## Testing
- `make -n`