### PR TITLE
Fix capability hashing and clean dead code

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -249,10 +249,10 @@ int             insert_pte(pde_t*, void*, uint64, int);
 #else
 int             insert_pte(pde_t*, void*, uint, int);
 #endif
-struct exo_cap  exo_alloc_page(void);
-int             exo_unbind_page(struct exo_cap);
-struct exo_cap  cap_new(uint id, uint rights, uint owner);
-int             cap_verify(struct exo_cap);
+exo_cap         exo_alloc_page(void);
+int             exo_unbind_page(exo_cap);
+exo_cap         cap_new(uint id, uint rights, uint owner);
+int             cap_verify(exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev, uint rights);
 int             exo_bind_block(struct exo_blockcap *, struct buf *, int);
 void            exo_flush_block(struct exo_blockcap *, void *);

--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -3,13 +3,6 @@
 #include "defs.h"
 #include <string.h>
 
-static uint cap_secret = 0xdeadbeef;
-
-static void
-gen_hash(uint id, uint rights, uint owner, hash256_t *out)
-{
-    for (int i = 0; i < 32; i++)
-        out->bytes[i] = (uchar)(cap_secret ^ id ^ rights ^ owner ^ i);
   
 /* Secret key used for capability HMAC */
 static const uint8_t cap_secret[32] = {

--- a/src-kernel/exo.c
+++ b/src-kernel/exo.c
@@ -22,6 +22,3 @@ void exo_pctr_transfer(struct trapframe *tf) {
   release(&ptable.lock);
 }
 
-int cap_verify(uint owner) {
-  return owner == myproc()->pid;
-}

--- a/src-kernel/kernel/exo_cpu.c
+++ b/src-kernel/kernel/exo_cpu.c
@@ -7,11 +7,10 @@
 
 int exo_yield_to(exo_cap target)
 {
-  if(target.id == 0)
   if (target.pa == 0)
     return -1;
-  if (!cap_verify(target.owner))
-  if(target.id == 0)
+  if (!cap_verify(target))
+    return -1;
 
   context_t *newctx = (context_t*)P2V(target.id);
   swtch(&myproc()->context, newctx);

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -96,20 +96,19 @@ int sys_exo_alloc_page(void) {
   exo_cap *ucap;
   if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  *ucap = exo_alloc_page();
   exo_cap cap = exo_alloc_page();
   memmove(ucap, &cap, sizeof(cap));
- return 0;
+  return 0;
 }
 
 // unbind and free a physical page by capability
 int sys_exo_unbind_page(void) {
+  exo_cap cap;
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0)
     return -1;
   if (!cap_verify(cap))
     return -1;
   return exo_unbind_page(cap);
-  memmove(&cap, ucap, sizeof(cap));
 }
 
 int sys_exo_alloc_block(void) {
@@ -273,20 +272,13 @@ int sys_proc_alloc(void) {
   np->state = RUNNABLE;
   release(&ptable.lock);
 
-  exo_cap cap = { V2P(np->context), myproc()->pid };
   exo_cap cap = cap_new(V2P(np->context), 0, np->pid);
   *ucap = cap;
 #ifdef __x86_64__
   return *(uint64_t *)&cap;
 #else
- return cap.pa;
+  return cap.pa;
 #endif
-  exo_cap *ucap;
-  if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
-    return -1;
-  exo_cap cap = cap_new(V2P(np->context), 0, curproc->pid);
-  memmove(ucap, &cap, sizeof(cap));
-  return 0;
 }
 
 int sys_set_numa_node(void) {

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -451,7 +451,7 @@ exo_alloc_page(void)
 int
 exo_unbind_page(exo_cap cap)
 {
-  if (!cap_verify(cap.owner))
+  if (!cap_verify(cap))
     return -1;
   struct proc *p = myproc();
   if(cap.owner != p->pid)


### PR DESCRIPTION
## Summary
- remove unused hashing implementation and use FNV/HMAC approach
- clean dead code after return statements
- fix capability API prototypes and update callers
- ensure files end with newline

## Testing
- `make -j$(nproc)` *(fails: `errno.h` not found)*