### PR TITLE
Fix typedef duplication in types.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,6 @@ endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
 endif
-endif
-
-endif
 
 $(XV6_IMG): bootblock kernel
 	dd if=/dev/zero of=$(XV6_IMG) count=10000

--- a/types.h
+++ b/types.h
@@ -6,31 +6,14 @@ typedef uint8_t  uchar;
 typedef uint16_t ushort;
 typedef uint32_t uint;
 typedef uint64_t uint64;
-
-#ifdef __x86_64__
-typedef uint64_t pde_t;
-typedef uint64_t uintptr_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
 typedef signed long long int64;
-
-typedef unsigned int uint32_t;
-typedef int int32_t;
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-
-typedef unsigned long uintptr_t;
 typedef unsigned int size_t;
 
 #ifdef __x86_64__
 typedef unsigned long long pde_t;
+typedef unsigned long uintptr_t;
 #else
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
 #endif
+


### PR DESCRIPTION
## Summary
- clean up repeated typedefs in `types.h`
- remove stray `endif` in `Makefile`

## Testing
- `make --no-print-directory | head -n 20` *(fails: conflicting type declarations in defs.h)*