### PR TITLE
Fix syscall numbering and build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ OBJS = \
 	sysfile.o\
 	sysproc.o\
 	trapasm.o\
-	trap.o\
-	uart.o\
-	vectors.o\
-	vm.o\
         trap.o\
         uart.o\
         vectors.o\
@@ -112,9 +108,6 @@ CFLAGS += -fno-pie -no-pie
 endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
-endif
-endif
-
 endif
 
 $(XV6_IMG): bootblock kernel

--- a/defs.h
+++ b/defs.h
@@ -23,6 +23,7 @@ struct stat;
 struct superblock;
 struct exo_cap;
 struct exo_blockcap;
+struct trapframe;
 
 #include "kernel/exo_cpu.h"
 #include "kernel/exo_disk.h"
@@ -40,10 +41,6 @@ void            consoleinit(void);
 void            cprintf(char*, ...);
 void            consoleintr(int(*)(void));
 [[noreturn]] void panic(char*);
-void consoleinit(void);
-void cprintf(char *, ...);
-void consoleintr(int (*)(void));
-void panic(char *) __attribute__((noreturn));
 
 // exec.c
 int exec(char *, char **);
@@ -76,32 +73,8 @@ struct inode*   nameiparent(char*, char*);
 int             readi(struct inode*, char*, uint, size_t);
 void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, char*, uint, size_t);
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
-void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
 
 // fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
-void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
 
 
 // ide.c
@@ -173,30 +146,11 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
+
 
 // PAGEBREAK: 16
 //  proc.c
-int cpuid(void);
-void exit(void);
-int fork(void);
-int growproc(int);
-int kill(int);
-struct cpu *mycpu(void);
-struct proc *myproc();
-void pinit(void);
-void procdump(void);
-void scheduler(void) __attribute__((noreturn));
-void sched(void);
-void setproc(struct proc *);
-void sleep(void *, struct spinlock *);
-void userinit(void);
-int wait(void);
-void wakeup(void *);
-void yield(void);
+
 
 
 // swtch.S
@@ -235,21 +189,7 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
 
-// syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
-void syscall(void);
 
 
 // timer.c
@@ -300,7 +240,6 @@ int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
 
-void clearpteu(pde_t *pgdir, char *uva);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,15 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/proc.h
+++ b/proc.h
@@ -80,7 +80,7 @@ struct proc {
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
 // Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -84,10 +84,7 @@ int argint(int n, int *ip) {
 // Fetch the nth word-sized system call argument as a pointer
 // to a block of memory of size bytes.  Check that the pointer
 // lies within the process address space.
-int
-argptr(int n, char **pp, size_t size)
-{
-int argptr(int n, char **pp, int size) {
+int argptr(int n, char **pp, size_t size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;
@@ -177,6 +174,7 @@ static int (*syscalls[])(void) = {
     [SYS_link] sys_link,
     [SYS_mkdir] sys_mkdir,
     [SYS_close] sys_close,
+    [SYS_mappte] sys_mappte,
     [SYS_set_timer_upcall] sys_set_timer_upcall,
     [SYS_exo_alloc_page] sys_exo_alloc_page,
     [SYS_exo_unbind_page] sys_exo_unbind_page,

--- a/syscall.h
+++ b/syscall.h
@@ -23,11 +23,9 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_mappte 22
-#define SYS_set_timer_upcall 22
-#define SYS_exo_alloc_page 23
-#define SYS_exo_unbind_page 24
-#define SYS_exo_alloc_block 25
-#define SYS_exo_bind_block 26
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
+#define SYS_set_timer_upcall 23
+#define SYS_exo_alloc_page 24
+#define SYS_exo_unbind_page 25
+#define SYS_exo_alloc_block 26
+#define SYS_exo_bind_block 27
 

--- a/sysproc.c
+++ b/sysproc.c
@@ -82,7 +82,7 @@ sys_mappte(void)
   if (argint(0, &va) < 0 || argint(1, &pa) < 0 || argint(2, &perm) < 0)
     return -1;
   return insert_pte(myproc()->pgdir, (void *)va, pa, perm);
-
+}
 
 int sys_set_timer_upcall(void) {
   void (*handler)(void);

--- a/types.h
+++ b/types.h
@@ -1,36 +1,18 @@
 #pragma once
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
 typedef uint16_t ushort;
 typedef uint32_t uint;
 typedef uint64_t uint64;
+typedef int64_t  int64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
 typedef uint64_t uintptr_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-typedef signed long long int64;
-
-typedef unsigned int uint32_t;
-typedef int int32_t;
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-
-typedef unsigned long uintptr_t;
-typedef unsigned int size_t;
-
-#ifdef __x86_64__
-typedef unsigned long long pde_t;
 #else
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
 #endif
+
+typedef unsigned int size_t;


### PR DESCRIPTION
## Summary
- fix duplicate object list and extraneous endif
- trim redundant prototypes and add trapframe forward declaration
- include mmu headers and ptable extern for exo.c
- correct syscall table and type definitions
- update struct proc size assertion

## Testing
- `make clean`
- `make`
