### PR TITLE
Add initial IPC endpoint support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,13 @@ OBJS = \
 	syscall.o\
 	sysfile.o\
 	sysproc.o\
-	trapasm.o\
-	trap.o\
-	uart.o\
-	vectors.o\
-	vm.o\
+        trapasm.o\
         trap.o\
         uart.o\
         vectors.o\
         vm.o\
         exo.o\
+        exo_ipc.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += mmu64.o
@@ -112,9 +109,6 @@ CFLAGS += -fno-pie -no-pie
 endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
-endif
-endif
-
 endif
 
 $(XV6_IMG): bootblock kernel

--- a/defs.h
+++ b/defs.h
@@ -299,6 +299,8 @@ struct exo_cap  exo_alloc_page(void);
 int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
+int             exo_send(struct exo_cap, const void *, uint64_t);
+int             exo_recv(struct exo_cap, void *, uint64_t);
 
 void clearpteu(pde_t *pgdir, char *uva);
 

--- a/exo_ipc.c
+++ b/exo_ipc.c
@@ -1,0 +1,47 @@
+#include "types.h"
+#include "defs.h"
+#include "proc.h"
+#include "kernel/exo_ipc.h"
+#include "spinlock.h"
+
+// Shared IPC frame allocated at boot
+char *exo_ipc_frame;
+static uint64_t exo_ipc_len;
+
+int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+  struct ipc_endpoint *ep = (struct ipc_endpoint*)P2V(dest.pa);
+  struct proc *p;
+
+  acquire(&ptable.lock);
+  p = ep->waiting;
+  if(p == 0){
+    release(&ptable.lock);
+    return -1;
+  }
+  ep->waiting = 0;
+  release(&ptable.lock);
+
+  if(len > 4*sizeof(uintptr_t))
+    memmove(exo_ipc_frame, buf, len);
+  else
+    memmove(exo_ipc_frame, buf, len);
+
+  exo_ipc_len = len;
+  wakeup(p);
+  return 0;
+}
+
+int exo_recv(exo_cap src, void *buf, uint64_t len) {
+  struct ipc_endpoint *ep = (struct ipc_endpoint*)P2V(src.pa);
+  struct proc *p = myproc();
+
+  acquire(&ptable.lock);
+  ep->waiting = p;
+  sleep(ep, &ptable.lock);
+  release(&ptable.lock);
+
+  if(len > exo_ipc_len)
+    len = exo_ipc_len;
+  memmove(buf, exo_ipc_frame, len);
+  return len;
+}

--- a/kernel/exo_ipc.h
+++ b/kernel/exo_ipc.h
@@ -2,5 +2,13 @@
 #include "exo_mem.h"
 #include "../exo.h"
 
+struct proc;
+
+struct ipc_endpoint {
+  uint badge;
+  struct proc *waiting;
+};
+
+extern char *exo_ipc_frame;
 int exo_send(exo_cap dest, const void *buf, uint64_t len);
 int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/proc.h
+++ b/proc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "exo.h"
+
 // Context used for kernel context switches.
 #ifdef __x86_64__
 struct context64;
@@ -78,9 +80,10 @@ struct proc {
   char name[16];               // Process name (debugging)
   uint pctr_cap;               // Capability for exo_pctr_transfer
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
+  exo_cap ep_cap;              // IPC endpoint capability
 };
-// Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+// Ensure scheduler and utilities rely on fixed proc size (128 bytes)
+_Static_assert(sizeof(struct proc) == 128, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -154,6 +154,8 @@ extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
 extern int sys_exo_alloc_block(void);
 extern int sys_exo_bind_block(void);
+extern int sys_exo_send(void);
+extern int sys_exo_recv(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -182,6 +184,8 @@ static int (*syscalls[])(void) = {
     [SYS_exo_unbind_page] sys_exo_unbind_page,
     [SYS_exo_alloc_block] sys_exo_alloc_block,
     [SYS_exo_bind_block] sys_exo_bind_block,
+    [SYS_exo_send] sys_exo_send,
+    [SYS_exo_recv] sys_exo_recv,
 };
 
 void syscall(void) {

--- a/syscall.h
+++ b/syscall.h
@@ -28,6 +28,8 @@
 #define SYS_exo_unbind_page 24
 #define SYS_exo_alloc_block 25
 #define SYS_exo_bind_block 26
+#define SYS_exo_send 27
+#define SYS_exo_recv 28
 #define SYS_exo_alloc_page 22
 #define SYS_exo_unbind_page 23
 

--- a/sysproc.c
+++ b/sysproc.c
@@ -82,6 +82,7 @@ sys_mappte(void)
   if (argint(0, &va) < 0 || argint(1, &pa) < 0 || argint(2, &perm) < 0)
     return -1;
   return insert_pte(myproc()->pgdir, (void *)va, pa, perm);
+}
 
 
 int sys_set_timer_upcall(void) {
@@ -143,4 +144,26 @@ int sys_exo_bind_block(void) {
     memmove(data, b.data, BSIZE);
   releasesleep(&b.lock);
   return 0;
+}
+
+int sys_exo_send(void) {
+  exo_cap dest;
+  char *buf;
+  uint64_t len;
+  if(argint(0, (int*)&dest.pa) < 0 || argint(2, (int*)&len) < 0)
+    return -1;
+  if(argptr(1, &buf, len) < 0)
+    return -1;
+  return exo_send(dest, buf, len);
+}
+
+int sys_exo_recv(void) {
+  exo_cap src;
+  char *buf;
+  uint64_t len;
+  if(argint(0, (int*)&src.pa) < 0 || argint(2, (int*)&len) < 0)
+    return -1;
+  if(argptr(1, &buf, len) < 0)
+    return -1;
+  return exo_recv(src, buf, len);
 }

--- a/user.h
+++ b/user.h
@@ -38,6 +38,8 @@ exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap);
 int exo_alloc_block(uint dev, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
+int exo_send(exo_cap dest, const void *buf, uint64_t len);
+int exo_recv(exo_cap src, void *buf, uint64_t len);
 
 
 // ulib.c

--- a/usys.S
+++ b/usys.S
@@ -60,5 +60,7 @@ SYSCALL(exo_alloc_page)
 SYSCALL(exo_unbind_page)
 SYSCALL(exo_alloc_block)
 SYSCALL(exo_bind_block)
+SYSCALL(exo_send)
+SYSCALL(exo_recv)
 
 


### PR DESCRIPTION
## Summary
- define `ipc_endpoint` structure
- extend process structure with endpoint capability
- allocate shared IPC frame on `userinit`
- implement minimal `exo_send`/`exo_recv` helpers
- expose new IPC system calls to user space
- fix extraneous `endif` in Makefile

## Testing
- `make --dry-run`