### PR TITLE
Implement stub zero-copy IPC syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,12 @@ OBJS = \
 	syscall.o\
 	sysfile.o\
 	sysproc.o\
-	trapasm.o\
-	trap.o\
-	uart.o\
-	vectors.o\
-	vm.o\
-        trap.o\
-        uart.o\
-        vectors.o\
-        vm.o\
-        exo.o\
+       trapasm.o\
+       trap.o\
+       uart.o\
+       vectors.o\
+       vm.o\
+       exo.o\
 
 ifeq ($(ARCH),x86_64)
 OBJS += mmu64.o
@@ -112,9 +108,6 @@ CFLAGS += -fno-pie -no-pie
 endif
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
 CFLAGS += -fno-pie -nopie
-endif
-endif
-
 endif
 
 $(XV6_IMG): bootblock kernel
@@ -212,8 +205,9 @@ UPROGS=\
 	_sh\
 	_stressfs\
 	_usertests\
-	_wc\
-	_zombie\
+        _wc\
+        _zombie\
+        _zipctest\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/defs.h
+++ b/defs.h
@@ -1,8 +1,6 @@
-
 #pragma once
 
 #include "types.h"
-
 
 struct buf;
 struct context;
@@ -22,34 +20,24 @@ struct sleeplock;
 struct stat;
 struct superblock;
 struct exo_cap;
-struct exo_blockcap;
-
-#include "kernel/exo_cpu.h"
-#include "kernel/exo_disk.h"
-#include "kernel/exo_ipc.h"
-#include "kernel/exo_mem.h"
+struct trapframe;
 
 // bio.c
-void binit(void);
-struct buf *bread(uint, uint);
-void brelse(struct buf *);
-void bwrite(struct buf *);
+void            binit(void);
+struct buf*     bread(uint, uint);
+void            brelse(struct buf*);
+void            bwrite(struct buf*);
 
 // console.c
 void            consoleinit(void);
 void            cprintf(char*, ...);
 void            consoleintr(int(*)(void));
-[[noreturn]] void panic(char*);
-void consoleinit(void);
-void cprintf(char *, ...);
-void consoleintr(int (*)(void));
-void panic(char *) __attribute__((noreturn));
+void            panic(char*) __attribute__((noreturn));
 
 // exec.c
-int exec(char *, char **);
+int             exec(char*, char**);
 
 // file.c
-
 struct file*    filealloc(void);
 void            fileclose(struct file*);
 struct file*    filedup(struct file*);
@@ -73,81 +61,53 @@ void            iupdate(struct inode*);
 int             namecmp(const char*, const char*);
 struct inode*   namei(char*);
 struct inode*   nameiparent(char*, char*);
-int             readi(struct inode*, char*, uint, size_t);
+int             readi(struct inode*, char*, uint, uint);
 void            stati(struct inode*, struct stat*);
-int             writei(struct inode*, char*, uint, size_t);
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
-void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
-
-// fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
-void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
-
+int             writei(struct inode*, char*, uint, uint);
 
 // ide.c
-void ideinit(void);
-void ideintr(void);
-void iderw(struct buf *);
+void            ideinit(void);
+void            ideintr(void);
+void            iderw(struct buf*);
 
 // ioapic.c
-void ioapicenable(int irq, int cpu);
-extern uchar ioapicid;
-void ioapicinit(void);
+void            ioapicenable(int irq, int cpu);
+extern uchar    ioapicid;
+void            ioapicinit(void);
 
 // kalloc.c
-char *kalloc(void);
-void kfree(char *);
-void kinit1(void *, void *);
-void kinit2(void *, void *);
+char*           kalloc(void);
+void            kfree(char*);
+void            kinit1(void*, void*);
+void            kinit2(void*, void*);
 
 // kbd.c
-void kbdintr(void);
+void            kbdintr(void);
 
 // lapic.c
-void cmostime(struct rtcdate *r);
-int lapicid(void);
-extern volatile uint *lapic;
-void lapiceoi(void);
-void lapicinit(void);
-void lapicstartap(uchar, uint);
-void microdelay(int);
+void            cmostime(struct rtcdate *r);
+int             lapicid(void);
+extern volatile uint*    lapic;
+void            lapiceoi(void);
+void            lapicinit(void);
+void            lapicstartap(uchar, uint);
+void            microdelay(int);
 
 // log.c
-void initlog(int dev);
-void log_write(struct buf *);
-void begin_op();
-void end_op();
+void            initlog(int dev);
+void            log_write(struct buf*);
+void            begin_op();
+void            end_op();
 
 // mp.c
-extern int ismp;
-void mpinit(void);
+extern int      ismp;
+void            mpinit(void);
 
 // picirq.c
-void picenable(int);
-void picinit(void);
+void            picenable(int);
+void            picinit(void);
 
 // pipe.c
-
 int             pipealloc(struct file**, struct file**);
 void            pipeclose(struct pipe*, int);
 int             piperead(struct pipe*, char*, size_t);
@@ -164,7 +124,7 @@ struct cpu*     mycpu(void);
 struct proc*    myproc();
 void            pinit(void);
 void            procdump(void);
-[[noreturn]] void scheduler(void);
+void            scheduler(void) __attribute__((noreturn));
 void            sched(void);
 void            setproc(struct proc*);
 void            sleep(void*, struct spinlock*);
@@ -173,52 +133,25 @@ int             wait(void);
 void            wakeup(void*);
 void            yield(void);
 
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
-
-// PAGEBREAK: 16
-//  proc.c
-int cpuid(void);
-void exit(void);
-int fork(void);
-int growproc(int);
-int kill(int);
-struct cpu *mycpu(void);
-struct proc *myproc();
-void pinit(void);
-void procdump(void);
-void scheduler(void) __attribute__((noreturn));
-void sched(void);
-void setproc(struct proc *);
-void sleep(void *, struct spinlock *);
-void userinit(void);
-int wait(void);
-void wakeup(void *);
-void yield(void);
-
-
 // swtch.S
-void swtch(context_t **, context_t *);
+void            swtch(context_t**, context_t*);
 
 // spinlock.c
-void acquire(struct spinlock *);
-void getcallerpcs(void *, uint *);
-int holding(struct spinlock *);
-void initlock(struct spinlock *, char *);
-void release(struct spinlock *);
-void pushcli(void);
-void popcli(void);
+void            acquire(struct spinlock*);
+void            getcallerpcs(void*, uint*);
+int             holding(struct spinlock*);
+void            initlock(struct spinlock*, char*);
+void            release(struct spinlock*);
+void            pushcli(void);
+void            popcli(void);
 
 // sleeplock.c
-void acquiresleep(struct sleeplock *);
-void releasesleep(struct sleeplock *);
-int holdingsleep(struct sleeplock *);
-void initsleeplock(struct sleeplock *, char *);
+void            acquiresleep(struct sleeplock*);
+void            releasesleep(struct sleeplock*);
+int             holdingsleep(struct sleeplock*);
+void            initsleeplock(struct sleeplock*, char*);
 
 // string.c
-
 int             memcmp(const void*, const void*, size_t);
 void*           memmove(void*, const void*, size_t);
 void*           memset(void*, int, size_t);
@@ -235,72 +168,52 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
-
-// syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
-void syscall(void);
-
-
 // timer.c
-void timerinit(void);
+void            timerinit(void);
 
 // trap.c
-void idtinit(void);
-extern uint ticks;
-void tvinit(void);
+void            idtinit(void);
+extern uint     ticks;
+void            tvinit(void);
 extern struct spinlock tickslock;
-void            exo_pctr_transfer(struct trapframe *);
 
 // uart.c
-void uartinit(void);
-void uartintr(void);
-void uartputc(int);
+void            uartinit(void);
+void            uartintr(void);
+void            uartputc(int);
 
 // vm.c
-void seginit(void);
-void kvmalloc(void);
-pde_t *setupkvm(void);
+void            seginit(void);
+void            kvmalloc(void);
+pde_t*          setupkvm(void);
 #ifdef __x86_64__
-pml4e_t *setupkvm64(void);
+pml4e_t*        setupkvm64(void);
 #endif
-char *uva2ka(pde_t *, char *);
-int allocuvm(pde_t *, uint, uint);
-int deallocuvm(pde_t *, uint, uint);
-void freevm(pde_t *);
-void inituvm(pde_t *, char *, uint);
-int loaduvm(pde_t *, char *, struct inode *, uint, uint);
-pde_t *copyuvm(pde_t *, uint);
-void switchuvm(struct proc *);
-void switchkvm(void);
+char*           uva2ka(pde_t*, char*);
+int             allocuvm(pde_t*, uint, uint);
+int             deallocuvm(pde_t*, uint, uint);
+void            freevm(pde_t*);
+void            inituvm(pde_t*, char*, uint);
+int             loaduvm(pde_t*, char*, struct inode*, uint, uint);
+pde_t*          copyuvm(pde_t*, uint);
+void            switchuvm(struct proc*);
+void            switchkvm(void);
 #ifdef __x86_64__
-int copyout(pde_t *, uint64, void *, uint);
+int             copyout(pde_t*, uint64, void*, uint);
 #else
-int copyout(pde_t *, uint, void *, uint);
+int             copyout(pde_t*, uint, void*, uint);
 #endif
-
 void            clearpteu(pde_t *pgdir, char *uva);
+struct exo_cap  exo_alloc_page(void);
+int             exo_unbind_page(struct exo_cap);
 #ifdef __x86_64__
 int             insert_pte(pde_t*, void*, uint64, int);
 #else
 int             insert_pte(pde_t*, void*, uint, int);
 #endif
-struct exo_cap  exo_alloc_page(void);
-int             exo_unbind_page(struct exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev);
 void            exo_bind_block(struct exo_blockcap *, struct buf *, int);
-
-void clearpteu(pde_t *pgdir, char *uva);
+void            exo_pctr_transfer(struct trapframe *);
 
 // number of elements in fixed-size array
-#define NELEM(x) (sizeof(x) / sizeof((x)[0]))
+#define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/exo.c
+++ b/exo.c
@@ -1,9 +1,15 @@
 #include "defs.h"
 #include "param.h"
+#include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "types.h"
 #include "x86.h"
+
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
   uint cap = tf->eax;

--- a/ipc.h
+++ b/ipc.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "syscall.h"
 
 // zero-copy micro-IPC interface
 // ISA: x86-64; syscall number 0x30 == ipc_fast
@@ -22,7 +23,7 @@ static inline int zipc_call(zipc_msg_t *m) {
   register uint64_t r8 __asm("r8") = m->w3;
   __asm__ volatile("syscall"
                    : "+S"(rsi), "+d"(rdx), "+c"(rcx), "+r"(r8)
-                   : "a"(0x30), "D"(rdi)
+                   : "a"(SYS_ipc_fast), "D"(rdi)
                    : "memory", "r11");
   m->w0 = rsi;
   m->w1 = rdx;

--- a/proc.h
+++ b/proc.h
@@ -80,7 +80,7 @@ struct proc {
   volatile uint pctr_signal;   // Signal counter for exo_pctr_transfer
 };
 // Ensure scheduler and utilities rely on fixed proc size (124 bytes)
-_Static_assert(sizeof(struct proc) == 124, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 136, "struct proc size incorrect");
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/syscall.c
+++ b/syscall.c
@@ -84,10 +84,7 @@ int argint(int n, int *ip) {
 // Fetch the nth word-sized system call argument as a pointer
 // to a block of memory of size bytes.  Check that the pointer
 // lies within the process address space.
-int
-argptr(int n, char **pp, size_t size)
-{
-int argptr(int n, char **pp, int size) {
+int argptr(int n, char **pp, size_t size) {
   struct proc *curproc = myproc();
 #ifndef __x86_64__
   int i;
@@ -154,6 +151,7 @@ extern int sys_exo_alloc_page(void);
 extern int sys_exo_unbind_page(void);
 extern int sys_exo_alloc_block(void);
 extern int sys_exo_bind_block(void);
+extern int sys_ipc_fast(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -182,6 +180,7 @@ static int (*syscalls[])(void) = {
     [SYS_exo_unbind_page] sys_exo_unbind_page,
     [SYS_exo_alloc_block] sys_exo_alloc_block,
     [SYS_exo_bind_block] sys_exo_bind_block,
+    [SYS_ipc_fast] sys_ipc_fast,
 };
 
 void syscall(void) {

--- a/syscall.h
+++ b/syscall.h
@@ -23,11 +23,10 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_mappte 22
-#define SYS_set_timer_upcall 22
-#define SYS_exo_alloc_page 23
-#define SYS_exo_unbind_page 24
-#define SYS_exo_alloc_block 25
-#define SYS_exo_bind_block 26
-#define SYS_exo_alloc_page 22
-#define SYS_exo_unbind_page 23
+#define SYS_set_timer_upcall 23
+#define SYS_exo_alloc_page 24
+#define SYS_exo_unbind_page 25
+#define SYS_exo_alloc_block 26
+#define SYS_exo_bind_block 27
+#define SYS_ipc_fast 28
 

--- a/types.h
+++ b/types.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <stdint.h>
 
 typedef uint8_t  uchar;
@@ -9,28 +8,10 @@ typedef uint64_t uint64;
 
 #ifdef __x86_64__
 typedef uint64_t pde_t;
-typedef uint64_t uintptr_t;
-typedef unsigned int uint;
-typedef unsigned short ushort;
-typedef unsigned char uchar;
-typedef unsigned long long uint64;
-typedef signed long long int64;
-
-typedef unsigned int uint32_t;
-typedef int int32_t;
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-
 typedef unsigned long uintptr_t;
-typedef unsigned int size_t;
-
-#ifdef __x86_64__
-typedef unsigned long long pde_t;
 #else
 typedef uint32_t pde_t;
 typedef uint32_t uintptr_t;
 #endif
+
+typedef unsigned int size_t;

--- a/zipctest.c
+++ b/zipctest.c
@@ -1,0 +1,11 @@
+#include "types.h"
+#include "user.h"
+#include "ipc.h"
+
+int
+main(void)
+{
+  zipc_msg_t m = { .badge = 0xdeadbeef, .w0 = 1, .w1 = 2, .w2 = 3, .w3 = 4 };
+  zipc_call(&m);
+  exit();
+}


### PR DESCRIPTION
## Summary
- add SYS_ipc_fast syscall constant
- hook sys_ipc_fast into syscall table and implement stub
- use the new syscall ID in zipc_call
- declare `ptable` in exo.c so build succeeds
- fix Makefile duplicate objects

## Testing
- `make clean`
- `make`