### PR TITLE
Move exo_ipc implementation under kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ LIBOS_DIR := libos
        $(KERNEL_DIR)/kernel/exo_cpu.o\
        $(KERNEL_DIR)/kernel/exo_disk.o\
        $(KERNEL_DIR)/kernel/exo_ipc.o\
+       $(KERNEL_DIR)/kernel/exo_ipc_queue.o\
        $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/cap.o\
        $(KERNEL_DIR)/fastipc.o\

--- a/src-kernel/kernel/exo_ipc.h
+++ b/src-kernel/kernel/exo_ipc.h
@@ -8,6 +8,11 @@ struct exo_ipc_ops {
   int (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
+/* Default in-kernel IPC queue implementation */
+extern struct exo_ipc_ops exo_ipc_queue_ops;
+int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
+int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+
 void exo_ipc_register(struct exo_ipc_ops *ops);
 int exo_send(exo_cap dest, const void *buf, uint64_t len);
 int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-kernel/kernel/exo_ipc_queue.c
+++ b/src-kernel/kernel/exo_ipc_queue.c
@@ -31,7 +31,7 @@ static void ipc_init(void) {
   }
 }
 
-int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
   ipc_init();
   if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
     return -EPERM;
@@ -67,7 +67,7 @@ int exo_send(exo_cap dest, const void *buf, uint64_t len) {
   return (int)len;
 }
 
-int exo_recv(exo_cap src, void *buf, uint64_t len) {
+int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
   if(!cap_has_rights(src.rights, EXO_RIGHT_R))
     return -EPERM;
   ipc_init();
@@ -103,3 +103,8 @@ int exo_recv(exo_cap src, void *buf, uint64_t len) {
 
   return (int)len;
 }
+
+struct exo_ipc_ops exo_ipc_queue_ops = {
+  .send = exo_ipc_queue_send,
+  .recv = exo_ipc_queue_recv,
+};

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -7,6 +7,7 @@
 #include "dag.h"
 #include "x86.h"
 #include "exo_stream.h"
+#include "kernel/exo_ipc.h"
 
 static void startothers(void);
 static void mpmain(void)  __attribute__((noreturn));
@@ -39,6 +40,7 @@ main(void)
   fileinit();      // file table
   ideinit();       // disk
   dag_sched_init(); // initialize DAG scheduler
+  exo_ipc_register(&exo_ipc_queue_ops);
   startothers();   // start other processors
   kinit2(P2V(4*1024*1024), P2V(PHYSTOP)); // must come after startothers()
   userinit();      // first user process


### PR DESCRIPTION
## Summary
- move the IPC queue implementation into `src-kernel/kernel`
- expose default queue send/recv via `exo_ipc_queue_ops`
- register the default ops during kernel init
- build the new implementation

## Testing
- `make` *(fails: struct trapframe mismatches)*