### PR TITLE
Add bare-metal cross compiler packages

### DIFF
--- a/README
+++ b/README
@@ -64,6 +64,10 @@ directory simply execute::
 
     sudo ./setup.sh
 
+This script installs bare-metal cross compiler packages such as
+``gcc-i386-elf``/``g++-i386-elf`` and ``gcc-x86-64-elf``/``g++-x86-64-elf``
+along with the rest of the toolchain.
+
 This only needs to be done after cloning the repository or when
 dependencies change.
 

--- a/setup.sh
+++ b/setup.sh
@@ -82,6 +82,13 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
+#— bare-metal ELF cross-compilers
+for pkg in \
+  gcc-i386-elf g++-i386-elf \
+  gcc-x86-64-elf g++-x86-64-elf; do
+  apt_pin_install "$pkg"
+done
+
 #— high-level language runtimes and tools
 for pkg in \
   golang-go nodejs npm typescript \


### PR DESCRIPTION
## Summary
- add gcc-i386-elf and gcc-x86-64-elf packages to setup script
- describe the new cross-compilers in the README

## Testing
- `make ARCH=i386` *(fails: string.h not found)*