### PR TITLE
Add Phoenix-capable libOS wrappers

### DIFF
--- a/libos/file.c
+++ b/libos/file.c
@@ -1,32 +1,59 @@
-#include "types.h"
-#include "user.h"
+#include "file.h"
+#include "fs.h"
+#include "include/exokernel.h"
 #include "sleeplock.h"
 #include "spinlock.h"
-#include "fs.h"
-#include "file.h"
+#include "types.h"
+#include "user.h"
 
 // Basic wrappers to illustrate linking a user-space filesystem library.
 
-struct file dummy_file;
+static struct file dummy_file;
 
 void fileinit(void) {}
 
 struct file *filealloc(void) {
-    return &dummy_file;
+  struct file *f = malloc(sizeof(struct file));
+  if (!f)
+    return 0;
+  *f = (struct file){.type = FD_CAP, .ref = 1};
+  return f;
 }
 
 struct file *filedup(struct file *f) {
-    return f;
+  if (f)
+    f->ref++;
+  return f;
 }
 
-void fileclose(struct file *f) {}
+void fileclose(struct file *f) {
+  if (!f)
+    return;
+  if (--f->ref == 0)
+    free(f);
+}
 
-int filestat(struct file *f, struct stat *st) { return fstat(0, st); }
+int filestat(struct file *f, struct stat *st) {
+  if (!f || !st)
+    return -1;
+  st->size = BSIZE; // minimal single-block file
+  return 0;
+}
 
 int fileread(struct file *f, char *addr, size_t n) {
-    return read(0, addr, n);
+  if (!f || !addr)
+    return -1;
+  int r = exo_read_disk(f->cap, addr, f->off, n);
+  if (r > 0)
+    f->off += r;
+  return r;
 }
 
 int filewrite(struct file *f, char *addr, size_t n) {
-    return write(0, addr, n);
+  if (!f || !addr)
+    return -1;
+  int r = exo_write_disk(f->cap, addr, f->off, n);
+  if (r > 0)
+    f->off += r;
+  return r;
 }

--- a/libos/file.h
+++ b/libos/file.h
@@ -1,37 +1,37 @@
 #pragma once
 
+#include "include/exokernel.h"
+
 struct file {
-  enum { FD_NONE, FD_PIPE, FD_INODE } type;
+  enum { FD_NONE, FD_CAP } type;
   size_t ref; // reference count
   char readable;
   char writable;
-  struct pipe *pipe;
-  struct inode *ip;
+  struct exo_blockcap cap; // backing storage capability
   size_t off;
 };
 
-
 // in-memory copy of an inode
 struct inode {
-  uint dev;           // Device number
-  uint inum;          // Inode number
+  uint dev;              // Device number
+  uint inum;             // Inode number
   size_t ref;            // Reference count
   struct sleeplock lock; // protects everything below here
-  int valid;          // inode has been read from disk?
+  int valid;             // inode has been read from disk?
 
-  short type;         // copy of disk inode
+  short type; // copy of disk inode
   short major;
   short minor;
   short nlink;
   size_t size;
-  uint addrs[NDIRECT+1];
+  uint addrs[NDIRECT + 1];
 };
 
 // table mapping major device number to
 // device functions
 struct devsw {
-  int (*read)(struct inode*, char*, size_t);
-  int (*write)(struct inode*, char*, size_t);
+  int (*read)(struct inode *, char *, size_t);
+  int (*write)(struct inode *, char *, size_t);
 };
 
 extern struct devsw devsw[];

--- a/libos/fs.c
+++ b/libos/fs.c
@@ -1,20 +1,25 @@
-#include "types.h"
-#include "user.h"
 #include "fs.h"
+#include "file.h"
+#include "include/exokernel.h"
 #include "sleeplock.h"
 #include "spinlock.h"
-#include "file.h"
+#include "types.h"
+#include "user.h"
 
 // Simplified user-space filesystem stubs using exokernel disk primitives.
 
-int
-fs_read_block(struct exo_blockcap cap, void *dst)
-{
-    return exo_read_disk(cap, dst, 0, BSIZE);
+int fs_read_block(struct exo_blockcap cap, void *dst) {
+  return exo_read_disk(cap, dst, 0, BSIZE);
 }
 
-int
-fs_write_block(struct exo_blockcap cap, const void *src)
-{
-    return exo_write_disk(cap, src, 0, BSIZE);
+int fs_write_block(struct exo_blockcap cap, const void *src) {
+  return exo_write_disk(cap, src, 0, BSIZE);
+}
+
+int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap) {
+  return exo_alloc_block(dev, rights, cap);
+}
+
+int fs_bind_block(struct exo_blockcap *cap, void *data, int write) {
+  return exo_bind_block(cap, data, write);
 }

--- a/libos/libfs.h
+++ b/libos/libfs.h
@@ -1,6 +1,9 @@
 #pragma once
-#include "fs.h"
 #include "file.h"
+#include "fs.h"
+#include "include/exokernel.h"
 
 int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);
+int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
+int fs_bind_block(struct exo_blockcap *cap, void *data, int write);

--- a/src-uland/caplib_example.c
+++ b/src-uland/caplib_example.c
@@ -1,9 +1,18 @@
 #include "caplib.h"
+#include "libos/libfs.h"
 #include "user.h"
 
 int main(void) {
   exo_cap page = cap_alloc_page();
   // use the page here ...
   cap_unbind_page(page);
+
+  struct exo_blockcap blk;
+  fs_alloc_block(1, EXO_RIGHT_R | EXO_RIGHT_W, &blk);
+  char buf[BSIZE] = "hello";
+  fs_write_block(blk, buf);
+  memset(buf, 0, sizeof(buf));
+  fs_read_block(blk, buf);
+  printf(1, "fs demo: %s\n", buf);
   exit();
 }


### PR DESCRIPTION
## Summary
- expand POSIX-like wrappers in `libos/file.c` and `libos/fs.c`
- carry Phoenix capability in `struct file`
- expose helpers in `libos/libfs.h`
- update `caplib_example` demo

## Testing
- `make libos` *(fails: No rule to make target 'src-uland/swtch.o')*