### PR TITLE
Add typed channel demo programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,14 @@ mkfs: mkfs.c fs.h
 	gcc -Werror -Wall -o mkfs mkfs.c
 
 $(ULAND_DIR)/exo_stream_demo.o: $(ULAND_DIR)/user/exo_stream_demo.c
+	$(CC) $(CFLAGS) -c -o $@ $<
 $(ULAND_DIR)/dag_demo.o: $(ULAND_DIR)/user/dag_demo.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+$(ULAND_DIR)/typed_chan_demo.o: $(ULAND_DIR)/user/typed_chan_demo.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+$(ULAND_DIR)/typed_chan_send.o: $(ULAND_DIR)/user/typed_chan_send.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+$(ULAND_DIR)/typed_chan_recv.o: $(ULAND_DIR)/user/typed_chan_recv.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 
@@ -288,6 +295,9 @@ UPROGS=\
         _ipc_test\
         _nbtest\
         _rcrs\
+        _typed_chan_demo\
+        _typed_chan_send\
+        _typed_chan_recv\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/README
+++ b/README
@@ -140,6 +140,15 @@ usual with ``make``; the resulting ``fs.img`` will contain the new
 ``exo_stream_demo`` binary.  Run it inside QEMU to observe the stub
 functions printing messages that indicate the expected invocation order.
 
+USER DEMO: TYPED CHANNELS
+-------------------------
+``typed_chan_demo`` showcases the ``CHAN_DECLARE`` macro that creates a
+typed wrapper around the basic capability IPC functions.  Building with
+``make`` will compile ``typed_chan_demo`` along with ``typed_chan_send``
+and ``typed_chan_recv`` under ``src-uland/user``.  After ``fs.img`` is
+generated, run ``typed_chan_demo`` inside QEMU to see a message sent and
+received through the typed channel API.
+
 
 IPC DESIGN NOTE
 ---------------

--- a/src-uland/user/typed_chan_demo.c
+++ b/src-uland/user/typed_chan_demo.c
@@ -1,0 +1,26 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+
+// simple typed message
+struct ping_msg {
+    int value;
+};
+
+CHAN_DECLARE(ping_chan, struct ping_msg);
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    ping_chan_t *c = ping_chan_create();
+    struct ping_msg msg = { 123 };
+    exo_cap cap = {0};
+    ping_chan_send(c, cap, &msg);
+    struct ping_msg out = {0};
+    ping_chan_recv(c, cap, &out);
+    printf(1, "typed channel message %d\n", out.value);
+    ping_chan_destroy(c);
+    exit();
+}
+

--- a/src-uland/user/typed_chan_recv.c
+++ b/src-uland/user/typed_chan_recv.c
@@ -1,0 +1,23 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+
+struct ping_msg {
+    int value;
+};
+
+CHAN_DECLARE(ping_chan, struct ping_msg);
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    ping_chan_t *c = ping_chan_create();
+    struct ping_msg out = {0};
+    exo_cap cap = {0};
+    ping_chan_recv(c, cap, &out);
+    printf(1, "received %d\n", out.value);
+    ping_chan_destroy(c);
+    exit();
+}
+

--- a/src-uland/user/typed_chan_send.c
+++ b/src-uland/user/typed_chan_send.c
@@ -1,0 +1,22 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+
+struct ping_msg {
+    int value;
+};
+
+CHAN_DECLARE(ping_chan, struct ping_msg);
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    ping_chan_t *c = ping_chan_create();
+    struct ping_msg m = { 7 };
+    exo_cap cap = {0};
+    ping_chan_send(c, cap, &m);
+    ping_chan_destroy(c);
+    exit();
+}
+


### PR DESCRIPTION
## Summary
- add `typed_chan_demo`, `typed_chan_send` and `typed_chan_recv` under `src-uland/user`
- build rules for the new demos
- include new binaries in the filesystem image
- document how to build and run the demos in the README

## Testing
- `make` *(fails: struct trapframe mismatches)*