### PR TITLE
Add basic driver management helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,9 +230,10 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/caplib.o \
         $(ULAND_DIR)/chan.o \
         $(ULAND_DIR)/math_core.o \
-        $(ULAND_DIR)/libos/sched.o \
+       $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
-        $(LIBOS_DIR)/file.o
+        $(LIBOS_DIR)/file.o \
+        $(LIBOS_DIR)/driver.o
 
 
 libos: libos.a

--- a/libos/driver.c
+++ b/libos/driver.c
@@ -1,0 +1,17 @@
+#include "driver.h"
+#include "user.h"
+
+int driver_spawn(const char *path, char *const argv[])
+{
+    int pid = fork();
+    if(pid == 0) {
+        exec((char *)path, (char **)argv);
+        exit();
+    }
+    return pid;
+}
+
+int driver_connect(int pid, exo_cap ep)
+{
+    return cap_send(ep, &pid, sizeof(pid));
+}

--- a/libos/driver.h
+++ b/libos/driver.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "types.h"
+#include "caplib.h"
+
+int driver_spawn(const char *path, char *const argv[]);
+int driver_connect(int pid, exo_cap ep);

--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -1,0 +1,1 @@
+../libos/driver.h


### PR DESCRIPTION
## Summary
- add `driver_spawn()` and `driver_connect()` in a new driver module
- expose the driver API via `libos/driver.h`
- link driver.o into the libos build
- export driver header in `src-headers`

## Testing
- `make libos` *(fails: No rule to make target 'src-uland/swtch.o')*