### PR TITLE
Implement driver liveness ping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ UPROGS=\
         _ipc_test\
         _nbtest\
         _rcrs\
+        _pingdriver\
         _typed_chan_demo\
         _typed_chan_send\
         _typed_chan_recv\

--- a/src-uland/pingdriver.c
+++ b/src-uland/pingdriver.c
@@ -1,0 +1,22 @@
+#include "types.h"
+#include "user.h"
+#include "ipc.h"
+
+#define PING 1
+#define PONG 2
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    zipc_msg_t m;
+    for(;;){
+        if(endpoint_recv(&m) < 0)
+            continue;
+        if(m.w0 == PING){
+            m.w0 = PONG;
+            endpoint_send(&m);
+        }
+    }
+    return 0;
+}

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -1,17 +1,44 @@
 #include "types.h"
 #include "user.h"
+#include "ipc.h"
+
+#define PING 1
+#define PONG 2
+#define PING_DELAY 20
 
 int
 main(void)
 {
-    char *argv[] = {"kbdserv", 0};
+    char *argv[] = {"pingdriver", 0};
     for(;;){
         int pid = fork();
         if(pid == 0){
-            exec("kbdserv", argv);
+            exec("pingdriver", argv);
             exit();
         }
-        wait();
+
+        int mon = fork();
+        if(mon == 0){
+            zipc_msg_t ping = {.w0 = PING};
+            zipc_msg_t pong;
+            for(;;){
+                endpoint_send(&ping);
+                if(endpoint_recv(&pong) < 0 || pong.w0 != PONG)
+                    exit();
+                sleep(PING_DELAY);
+            }
+        }
+
+        int died = wait();
+        if(died == mon){
+            printf(1, "supervisor: restarting driver (timeout)\n");
+            kill(pid);
+            wait();
+        } else {
+            printf(1, "supervisor: driver exited\n");
+            kill(mon);
+            wait();
+        }
     }
     return 0;
 }

--- a/user.h
+++ b/user.h
@@ -44,8 +44,9 @@ int set_gas(uint64 amount);
 int get_gas(void);
 int exo_send(exo_cap *dest, const void *buf, uint64 len);
 int exo_recv(exo_cap *src, void *buf, uint64 len);
-int endpoint_send(chan_t *c, exo_cap dest, const void *msg);
-int endpoint_recv(chan_t *c, exo_cap src, void *msg);
+struct zipc_msg_t; /* forward declaration */
+int endpoint_send(struct zipc_msg_t *msg);
+int endpoint_recv(struct zipc_msg_t *msg);
 int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 int proc_alloc(exo_cap *cap);


### PR DESCRIPTION
## Summary
- declare endpoint_send/recv with zipc_msg_t signature
- add simple pingdriver that responds to endpoint pings
- supervise pingdriver in rcrs using ping messages
- build pingdriver by default

## Testing
- `make clean`
- `make` *(fails: struct trapframe has no member named rax)*