### PR TITLE
Refine driver docs

### DIFF
--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -198,3 +198,17 @@ int main(void) {
 Compile the file with `make` and add the resulting binary to the disk image.
 The supervisor can then spawn the driver at boot time or restart it if it
 exits.
+
+### Driver Management Helpers
+
+Convenience functions in `libos/driver.h` assist with launching and
+connecting to drivers:
+
+```c
+int driver_spawn(const char *path, char *const argv[]);
+int driver_connect(int pid, exo_cap ep);
+```
+
+`driver_spawn` forks and executes the given program while
+`driver_connect` sends an endpoint capability to an already running
+driver.

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -1,7 +1,7 @@
 /*
  * rcrs - restartable driver supervisor
  *
- * This user-level helper reads command lines from /drivers.conf and
+ * This user-level helper reads command lines from drivers.conf and
  * keeps the specified programs running.  Each non-empty line in the
  * configuration file represents one driver.  Lines beginning with '#'
  * are treated as comments.  When a driver process exits the supervisor
@@ -9,7 +9,7 @@
  *
  * Example configuration:
  *   kbdserv
- *   otherdriver arg1 arg2
+ *   pingdriver
  */
 #include "fcntl.h"
 #include "stat.h"


### PR DESCRIPTION
## Summary
- fix rcrs comment to mention drivers.conf path
- document libOS driver helpers in phoenixkernel

## Testing
- `make` *(fails: struct trapframe lacks members rdi/rsi etc.)*