### PR TITLE
Add basic capability table and reference syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ LIBOS_DIR := libos
        $(KERNEL_DIR)/kernel/exo_ipc_queue.o\
        $(KERNEL_DIR)/exo_stream.o\
        $(KERNEL_DIR)/cap.o\
+       $(KERNEL_DIR)/cap_table.o\
        $(KERNEL_DIR)/fastipc.o\
        $(KERNEL_DIR)/endpoint.o\
        $(KERNEL_DIR)/dag_sched.o

--- a/cap.h
+++ b/cap.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "types.h"
+
+#define CAP_MAX 1024
+
+enum cap_type {
+    CAP_TYPE_NONE = 0,
+    CAP_TYPE_PAGE = 1,
+};
+
+struct cap_entry {
+    uint16_t type;
+    uint16_t refcnt;
+    uint resource;
+    uint rights;
+    uint owner;
+};
+
+void cap_table_init(void);
+int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner);
+int cap_table_lookup(uint16_t id, struct cap_entry *out);
+void cap_table_inc(uint16_t id);
+void cap_table_dec(uint16_t id);
+int cap_table_remove(uint16_t id);

--- a/caplib.h
+++ b/caplib.h
@@ -18,3 +18,5 @@ int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
 int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 int cap_ipc_echo_demo(void);
+int cap_inc(uint16_t id);
+int cap_dec(uint16_t id);

--- a/defs.h
+++ b/defs.h
@@ -6,6 +6,7 @@
 #include "spinlock.h"
 #include "proc.h"
 #include "ipc.h"
+#include "cap.h"
 
 
 
@@ -257,6 +258,12 @@ int             cap_verify(exo_cap);
 struct exo_blockcap exo_alloc_block(uint dev, uint rights);
 int             exo_bind_block(struct exo_blockcap *, struct buf *, int);
 void            exo_flush_block(struct exo_blockcap *, void *);
+void            cap_table_init(void);
+int             cap_table_alloc(uint16_t, uint, uint, uint);
+int             cap_table_lookup(uint16_t, struct cap_entry *);
+void            cap_table_inc(uint16_t);
+void            cap_table_dec(uint16_t);
+int             cap_table_remove(uint16_t);
 void            exo_stream_register(struct exo_stream *);
 void            exo_stream_halt(void);
 void            exo_stream_yield(void);

--- a/include/exokernel.h
+++ b/include/exokernel.h
@@ -75,5 +75,7 @@ enum exo_syscall {
     EXO_SYSCALL_RECV        = SYS_exo_recv,
     EXO_SYSCALL_READ_DISK   = SYS_exo_read_disk,
     EXO_SYSCALL_WRITE_DISK  = SYS_exo_write_disk,
+    EXO_SYSCALL_CAP_INC     = SYS_cap_inc,
+    EXO_SYSCALL_CAP_DEC     = SYS_cap_dec,
 };
 

--- a/src-kernel/cap_table.c
+++ b/src-kernel/cap_table.c
@@ -1,0 +1,69 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "cap.h"
+#include <string.h>
+
+static struct spinlock cap_lock;
+static struct cap_entry cap_table[CAP_MAX];
+
+void cap_table_init(void) {
+    initlock(&cap_lock, "captbl");
+    memset(cap_table, 0, sizeof(cap_table));
+}
+
+int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
+    acquire(&cap_lock);
+    for (int i = 1; i < CAP_MAX; i++) {
+        if (cap_table[i].type == CAP_TYPE_NONE) {
+            cap_table[i].type = type;
+            cap_table[i].resource = resource;
+            cap_table[i].rights = rights;
+            cap_table[i].owner = owner;
+            cap_table[i].refcnt = 1;
+            release(&cap_lock);
+            return i;
+        }
+    }
+    release(&cap_lock);
+    return -1;
+}
+
+int cap_table_lookup(uint16_t id, struct cap_entry *out) {
+    acquire(&cap_lock);
+    if (id >= CAP_MAX || cap_table[id].type == CAP_TYPE_NONE) {
+        release(&cap_lock);
+        return -1;
+    }
+    if (out)
+        *out = cap_table[id];
+    release(&cap_lock);
+    return 0;
+}
+
+void cap_table_inc(uint16_t id) {
+    acquire(&cap_lock);
+    if (id < CAP_MAX && cap_table[id].type != CAP_TYPE_NONE)
+        cap_table[id].refcnt++;
+    release(&cap_lock);
+}
+
+void cap_table_dec(uint16_t id) {
+    acquire(&cap_lock);
+    if (id < CAP_MAX && cap_table[id].type != CAP_TYPE_NONE) {
+        if (--cap_table[id].refcnt == 0)
+            cap_table[id].type = CAP_TYPE_NONE;
+    }
+    release(&cap_lock);
+}
+
+int cap_table_remove(uint16_t id) {
+    acquire(&cap_lock);
+    if (id >= CAP_MAX || cap_table[id].type == CAP_TYPE_NONE) {
+        release(&cap_lock);
+        return -1;
+    }
+    cap_table[id].type = CAP_TYPE_NONE;
+    release(&cap_lock);
+    return 0;
+}

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -5,6 +5,7 @@
 #include "mmu.h"
 #include "proc.h"
 #include "dag.h"
+#include "cap.h"
 #include "x86.h"
 #include "exo_stream.h"
 #include "kernel/exo_ipc.h"
@@ -33,6 +34,7 @@ main(void)
   ioapicinit();    // another interrupt controller
   consoleinit();   // console hardware
   uartinit();      // serial port
+  cap_table_init(); // initialize capability table
   rcuinit();       // rcu subsystem
   pinit();         // process table
   tvinit();        // trap vectors

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -165,6 +165,8 @@ extern int sys_ipc_fast(void);
 extern int sys_fcntl(void);
 extern int sys_sigsend(void);
 extern int sys_sigcheck(void);
+extern int sys_cap_inc(void);
+extern int sys_cap_dec(void);
 
 static int (*syscalls[])(void) = {
     [SYS_fork] sys_fork,
@@ -208,6 +210,8 @@ static int (*syscalls[])(void) = {
     [SYS_fcntl] sys_fcntl,
     [SYS_sigsend] sys_sigsend,
     [SYS_sigcheck] sys_sigcheck,
+    [SYS_cap_inc] sys_cap_inc,
+    [SYS_cap_dec] sys_cap_dec,
     [SYS_ipc_fast] sys_ipc_fast,
 };
 

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -9,6 +9,7 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "param.h"
+#include "cap.h"
 #include "proc.h"
 #include "spinlock.h"
 #include "x86.h"
@@ -314,6 +315,22 @@ int sys_sigcheck(void) {
   int s = myproc()->pending_signal;
   myproc()->pending_signal = 0;
   return s;
+}
+
+int sys_cap_inc(void) {
+  int id;
+  if (argint(0, &id) < 0)
+    return -1;
+  cap_table_inc((uint16_t)id);
+  return 0;
+}
+
+int sys_cap_dec(void) {
+  int id;
+  if (argint(0, &id) < 0)
+    return -1;
+  cap_table_dec((uint16_t)id);
+  return 0;
 }
 
 // Provided by fastipc.c

--- a/syscall.h
+++ b/syscall.h
@@ -44,4 +44,6 @@
 #define SYS_fcntl 0x31
 #define SYS_sigsend 0x32
 #define SYS_sigcheck 0x33
+#define SYS_cap_inc 0x34
+#define SYS_cap_dec 0x35
 

--- a/user.h
+++ b/user.h
@@ -54,6 +54,8 @@ int set_numa_node(int);
 int fcntl(int, int, int);
 int sigsend(int, int);
 int sigcheck(void);
+int cap_inc(uint16_t id);
+int cap_dec(uint16_t id);
 
 // ulib.c
 int stat(const char *, struct stat *);

--- a/usys.S
+++ b/usys.S
@@ -75,6 +75,8 @@ SYSCALL(set_numa_node)
 SYSCALL(fcntl)
 SYSCALL(sigsend)
 SYSCALL(sigcheck)
+SYSCALL(cap_inc)
+SYSCALL(cap_dec)
 
 
 


### PR DESCRIPTION
## Summary
- introduce a kernel capability table with refcounts
- implement `cap_table_alloc`, lookup and refcount operations
- add `cap_inc`/`cap_dec` syscalls and user stubs
- adjust page capability allocation to use the table

## Testing
- `make` *(fails: cc1: all warnings being treated as errors)*