### PR TITLE
Add clang-tidy configs for C23 and C++17

### DIFF
--- a/.clang-tidy-cpp17
+++ b/.clang-tidy-cpp17
@@ -2,4 +2,4 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
-Standard: c23
+Standard: c++17

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,16 @@ repos:
       name: clang-format
       entry: clang-format -i
       language: system
-      types: [c, h]
-    - id: clang-tidy
-      name: clang-tidy
-      entry: clang-tidy
+      types: [c, h, cpp, cxx, hpp, hxx, cc, hh]
+    - id: clang-tidy-c23
+      name: clang-tidy (C23)
+      entry: clang-tidy --config-file=.clang-tidy
       language: system
       pass_filenames: true
       types: [c, h]
+    - id: clang-tidy-cpp17
+      name: clang-tidy (C++17)
+      entry: clang-tidy --config-file=.clang-tidy-cpp17
+      language: system
+      pass_filenames: true
+      types: [cpp, cxx, cc, c++, hpp, hxx, hh]


### PR DESCRIPTION
## Summary
- support clang-tidy with C23 and C++17 configs
- expand pre-commit config to run clang-tidy for C and C++

## Testing
- `make clean`
- `make` *(fails: data definition has no type or storage class)*
- `pre-commit run --files .clang-tidy .pre-commit-config.yaml` *(fails: command not found)*