### PR TITLE
Add libSMK capability wrapper and example

### DIFF
--- a/libsmk_cap.h
+++ b/libsmk_cap.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "types.h"
+#include "user.h"
+
+/* Lightweight capability wrapper used by libSMK. */
+typedef struct {
+  uint16_t id;
+} cap_t;
+
+static inline void borrow(cap_t c) { cap_inc(c.id); }
+static inline void drop(cap_t c) { cap_dec(c.id); }

--- a/proto/hello.capnp
+++ b/proto/hello.capnp
@@ -1,0 +1,3 @@
+struct Hello {
+  value @0 : Int32;
+}

--- a/src-uland/user/hello_channel.c
+++ b/src-uland/user/hello_channel.c
@@ -1,0 +1,30 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+#include "caplib.h"
+#include "libsmk_cap.h"
+#include "proto/hello.capnp.h"
+
+CHAN_DECLARE(hello_chan, Hello);
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  hello_chan_t *c = hello_chan_create();
+  exo_cap page = cap_alloc_page();
+  cap_t cap = {.id = page.id};
+  borrow(cap);
+  if (fork() == 0) {
+    Hello msg = {.value = 42};
+    hello_chan_send(c, page, &msg);
+    drop(cap);
+    exit();
+  } else {
+    Hello out = {0};
+    hello_chan_recv(c, page, &out);
+    printf(1, "child sent %d\n", out.value);
+    drop(cap);
+    hello_chan_destroy(c);
+  }
+  exit();
+}


### PR DESCRIPTION
## Summary
- add `libsmk_cap.h` providing borrow/drop wrappers around capability refs
- add small `Hello` Cap'n Proto schema
- add `hello_channel` demo showing basic send/recv with borrow/drop

## Testing
- `clang-format -i libsmk_cap.h proto/hello.capnp src-uland/user/hello_channel.c`
- `pre-commit` *(fails: command not found)*