### PR TITLE
Add typed channel validation and docs

### DIFF
--- a/chan.h
+++ b/chan.h
@@ -15,8 +15,8 @@ chan_t *chan_create(const struct msg_type_desc *desc);
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg);
-int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg);
+int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len);
+int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
@@ -35,11 +35,13 @@ int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg);
     static inline int name##_send(name##_t *c, exo_cap dest, const type *m){ \
         unsigned char buf[type##_MESSAGE_SIZE];                     \
         type##_encode(m, buf);                                      \
-        return chan_endpoint_send(&c->base, dest, buf);             \
+        return chan_endpoint_send(&c->base, dest, buf,              \
+                                  type##_MESSAGE_SIZE);             \
     }                                                               \
     static inline int name##_recv(name##_t *c, exo_cap src, type *m){ \
         unsigned char buf[type##_MESSAGE_SIZE];                     \
-        int r = chan_endpoint_recv(&c->base, src, buf);             \
+        int r = chan_endpoint_recv(&c->base, src, buf,              \
+                                   type##_MESSAGE_SIZE);            \
         if(r == 0)                                                 \
             type##_decode(m, buf);                                  \
         return r;                                                   \

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -155,6 +155,17 @@ transports serialized Cap'n Proto messages. Applications define their RPC
 interfaces in `.capnp` files and rely on the Cap'n Proto C bindings to
 generate the encoding and decoding routines.
 
+### Typed Channels
+
+For convenience the libOS provides typed channels declared with the
+`CHAN_DECLARE` macro in `chan.h`.  Each typed channel associates a Cap'n
+Proto message type with a channel descriptor so that `send` and `recv`
+automatically encode and decode the messages.  The Cap'n Proto workflow
+generates `<name>.capnp.h` files defining `type_MESSAGE_SIZE` constants
+and the corresponding `type_encode`/`type_decode` helpers.  A typed channel
+uses these helpers to serialize exactly `msg_size` bytes when interacting
+with an endpoint.  See `typed_chan_demo.c` for an example.
+
 ## libOS APIs
 
 The libOS includes wrappers around the capability syscalls as well as helper

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -20,14 +20,18 @@ chan_destroy(chan_t *c)
 }
 
 int
-chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg)
+chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len)
 {
+    if(len != c->msg_size)
+        return -1;
     return cap_send(dest, msg, c->msg_size);
 }
 
 int
-chan_endpoint_recv(chan_t *c, exo_cap src, void *msg)
+chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len)
 {
+    if(len != c->msg_size)
+        return -1;
     return cap_recv(src, msg, c->msg_size);
 }
 

--- a/src-uland/user/typed_chan_demo.c
+++ b/src-uland/user/typed_chan_demo.c
@@ -16,6 +16,11 @@ main(int argc, char *argv[])
     DriverPing out = {0};
     ping_chan_recv(c, cap, &out);
     printf(1, "typed channel message %d\n", out.value);
+
+    // Demonstrate size validation by calling the generic endpoint helpers
+    char bad[1] = {0};
+    int r = chan_endpoint_send(&c->base, cap, bad, sizeof(bad));
+    printf(1, "bad send result %d\n", r);
     ping_chan_destroy(c);
     exit();
 }


### PR DESCRIPTION
## Summary
- document typed channels in Phoenix kernel overview
- validate buffer length in `chan_endpoint_send` and `chan_endpoint_recv`
- show failure case in `typed_chan_demo`

## Testing
- `pre-commit` *(fails: command not found)*
- `make _typed_chan_demo` *(fails: missing driver.capnp.h)*