### PR TITLE
Implement basic libos POSIX wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,8 @@ LIBOS_OBJS = \
        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
         $(LIBOS_DIR)/file.o \
-        $(LIBOS_DIR)/driver.o
+        $(LIBOS_DIR)/driver.o \
+        $(LIBOS_DIR)/posix.o
 
 
 libos: libos.a
@@ -313,6 +314,7 @@ UPROGS=\
         _typed_chan_demo\
         _typed_chan_send\
         _typed_chan_recv\
+        _libos_posix_test\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -1,0 +1,95 @@
+#include "posix.h"
+#include "file.h"
+#include "libfs.h"
+#include "string.h"
+#include "user.h"
+
+#define LIBOS_MAXFD 16
+#define LIBOS_MAXFILES 8
+
+static struct file *fd_table[LIBOS_MAXFD];
+
+struct vfile {
+    char path[32];
+    int used;
+    struct exo_blockcap cap;
+};
+
+static struct vfile vfiles[LIBOS_MAXFILES];
+
+static struct vfile *lookup_vfile(const char *path) {
+    for(int i = 0; i < LIBOS_MAXFILES; i++) {
+        if(vfiles[i].used && strcmp(vfiles[i].path, path) == 0)
+            return &vfiles[i];
+    }
+    return 0;
+}
+
+static struct vfile *create_vfile(const char *path) {
+    for(int i = 0; i < LIBOS_MAXFILES; i++) {
+        if(!vfiles[i].used) {
+            if(fs_alloc_block(1, EXO_RIGHT_R | EXO_RIGHT_W, &vfiles[i].cap) < 0)
+                return 0;
+            strncpy(vfiles[i].path, path, sizeof(vfiles[i].path)-1);
+            vfiles[i].path[sizeof(vfiles[i].path)-1] = '\0';
+            vfiles[i].used = 1;
+            return &vfiles[i];
+        }
+    }
+    return 0;
+}
+
+int libos_open(const char *path, int flags) {
+    (void)flags;
+    struct file *f = filealloc();
+    if(!f)
+        return -1;
+    struct vfile *vf = lookup_vfile(path);
+    if(!vf)
+        vf = create_vfile(path);
+    if(!vf) {
+        free(f);
+        return -1;
+    }
+    f->cap = vf->cap;
+    f->readable = 1;
+    f->writable = 1;
+    f->off = 0;
+    for(int i = 0; i < LIBOS_MAXFD; i++) {
+        if(!fd_table[i]) {
+            fd_table[i] = f;
+            return i;
+        }
+    }
+    fileclose(f);
+    return -1;
+}
+
+int libos_read(int fd, void *buf, size_t n) {
+    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+        return -1;
+    return fileread(fd_table[fd], buf, n);
+}
+
+int libos_write(int fd, const void *buf, size_t n) {
+    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+        return -1;
+    return filewrite(fd_table[fd], (char *)buf, n);
+}
+
+int libos_close(int fd) {
+    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+        return -1;
+    fileclose(fd_table[fd]);
+    fd_table[fd] = 0;
+    return 0;
+}
+
+int libos_spawn(const char *path, char *const argv[]) {
+    int pid = fork();
+    if(pid == 0) {
+        exec((char *)path, (char **)argv);
+        exit();
+    }
+    return pid;
+}

--- a/libos/posix.h
+++ b/libos/posix.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "types.h"
+
+int libos_open(const char *path, int flags);
+int libos_read(int fd, void *buf, size_t n);
+int libos_write(int fd, const void *buf, size_t n);
+int libos_close(int fd);
+int libos_spawn(const char *path, char *const argv[]);

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "types.h"
+
+int libos_open(const char *path, int flags);
+int libos_read(int fd, void *buf, size_t n);
+int libos_write(int fd, const void *buf, size_t n);
+int libos_close(int fd);
+int libos_spawn(const char *path, char *const argv[]);

--- a/src-uland/libos_posix_test.c
+++ b/src-uland/libos_posix_test.c
@@ -1,0 +1,43 @@
+#include "libos/posix.h"
+#include "user.h"
+#include "string.h"
+#include "libos/libfs.h"
+
+int main(void) {
+    const char *msg = "hello";
+    int fd = libos_open("testfile", 0);
+    if(fd < 0){
+        printf(1, "posix_test: open failed\n");
+        exit();
+    }
+    if(libos_write(fd, msg, strlen(msg)) != (int)strlen(msg)) {
+        printf(1, "posix_test: write failed\n");
+        exit();
+    }
+    libos_close(fd);
+
+    fd = libos_open("testfile", 0);
+    char buf[16];
+    int n = libos_read(fd, buf, sizeof(buf)-1);
+    if(n < 0){
+        printf(1, "posix_test: read failed\n");
+        exit();
+    }
+    buf[n] = '\0';
+    if(strcmp(buf, msg) != 0){
+        printf(1, "posix_test: mismatch %s\n", buf);
+        exit();
+    }
+    libos_close(fd);
+
+    char *argv[] = {"echo", "spawn", 0};
+    int pid = libos_spawn("echo", argv);
+    if(pid < 0){
+        printf(1, "posix_test: spawn failed\n");
+        exit();
+    }
+    wait();
+
+    printf(1, "libos_posix_test passed\n");
+    exit();
+}


### PR DESCRIPTION
## Summary
- add simple POSIX-like helpers to libos
- expose open/read/write/close/spawn in `posix.h`
- compile new helpers into `libos.a`
- add unit test exercising the helpers

## Testing
- `make libos` *(fails: No rule to make target 'src-uland/swtch.o')*