### PR TITLE
Add priority queue support to DAG scheduler

### DIFF
--- a/dag.h
+++ b/dag.h
@@ -12,6 +12,7 @@ struct dag_node_list {
 struct dag_node {
   exo_cap ctx;
   int pending;
+  int priority;
   struct dag_node_list *children;
   struct dag_node *next;
   struct dag_node **deps;
@@ -21,6 +22,7 @@ struct dag_node {
 };
 
 void dag_node_init(struct dag_node *n, exo_cap ctx);
+void dag_node_set_priority(struct dag_node *n, int priority);
 void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
 void dag_sched_submit(struct dag_node *node);
 void dag_sched_init(void);

--- a/defs.h
+++ b/defs.h
@@ -264,6 +264,7 @@ int sys_ipc_fast(void);
 void endpoint_send(struct endpoint *, zipc_msg_t *);
 int endpoint_recv(struct endpoint *, zipc_msg_t *);
 void dag_node_init(struct dag_node *, exo_cap);
+void dag_node_set_priority(struct dag_node *, int);
 void dag_node_add_dep(struct dag_node *, struct dag_node *);
 void dag_sched_submit(struct dag_node *);
 

--- a/libos/sched.h
+++ b/libos/sched.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "dag.h"
+
+static inline void dag_node_set_priority(struct dag_node *n, int priority)
+{
+    n->priority = priority;
+}

--- a/src-headers/libos/sched.h
+++ b/src-headers/libos/sched.h
@@ -1,0 +1,1 @@
+../libos/sched.h

--- a/src-kernel/dag_sched.c
+++ b/src-kernel/dag_sched.c
@@ -20,6 +20,12 @@ dag_node_init(struct dag_node *n, exo_cap ctx)
 }
 
 void
+dag_node_set_priority(struct dag_node *n, int priority)
+{
+  n->priority = priority;
+}
+
+void
 dag_node_add_dep(struct dag_node *parent, struct dag_node *child)
 {
   struct dag_node_list *l = (struct dag_node_list *)kalloc();
@@ -34,8 +40,11 @@ dag_node_add_dep(struct dag_node *parent, struct dag_node *child)
 static void
 enqueue_ready(struct dag_node *n)
 {
-  n->next = ready_head;
-  ready_head = n;
+  struct dag_node **pp = &ready_head;
+  while(*pp && (*pp)->priority >= n->priority)
+    pp = &(*pp)->next;
+  n->next = *pp;
+  *pp = n;
 }
 
 void

--- a/src-uland/user/dag_demo.c
+++ b/src-uland/user/dag_demo.c
@@ -1,19 +1,20 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "libos/sched.h"
 
 typedef struct exo_cap { uint32_t pa; } exo_cap;
 
-struct dag_node { int pending; };
+struct dag_node { int pending; int priority; };
 
 static void dag_node_init(struct dag_node *n, exo_cap ctx) {
-  (void)ctx; n->pending = 0;
+  (void)ctx; n->pending = 0; n->priority = 0;
 }
 static void dag_node_add_dep(struct dag_node *parent, struct dag_node *child) {
   (void)parent; (void)child;
 }
 static void dag_sched_submit(struct dag_node *node) {
-  (void)node; printf("dag_sched_submit\n");
+  printf("dag_sched_submit priority %d\n", node->priority);
 }
 static void exo_stream_yield(void) {
   printf("exo_stream_yield called\n");
@@ -24,8 +25,11 @@ static struct dag_node a, b, c;
 static void setup(void) {
   exo_cap cap = {0};
   dag_node_init(&a, cap);
+  dag_node_set_priority(&a, 10);
   dag_node_init(&b, cap);
+  dag_node_set_priority(&b, 5);
   dag_node_init(&c, cap);
+  dag_node_set_priority(&c, 1);
   dag_node_add_dep(&a, &c);
   dag_node_add_dep(&b, &c);
   dag_sched_submit(&a);
@@ -37,6 +41,8 @@ int main(int argc, char *argv[]) {
   (void)argc; (void)argv;
   printf("DAG scheduler demo\n");
   setup();
+  exo_stream_yield();
+  exo_stream_yield();
   exo_stream_yield();
   return 0;
 }


### PR DESCRIPTION
## Summary
- support priority-aware ready queue in kernel DAG scheduler
- expose node priority helper through new `libos/sched.h`
- demonstrate priorities in `dag_demo.c`

## Testing
- `make check`