### PR TITLE
Update docs and add combined IPC demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,11 @@ $(ULAND_DIR)/typed_chan_demo.o: $(ULAND_DIR)/user/typed_chan_demo.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 $(ULAND_DIR)/typed_chan_send.o: $(ULAND_DIR)/user/typed_chan_send.c
 	$(CC) $(CFLAGS) -c -o $@ $<
+
 $(ULAND_DIR)/typed_chan_recv.o: $(ULAND_DIR)/user/typed_chan_recv.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(ULAND_DIR)/chan_dag_supervisor_demo.o: $(ULAND_DIR)/user/chan_dag_supervisor_demo.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 	# Generate simple C bindings from Cap'n Proto schemas
@@ -313,6 +317,7 @@ UPROGS=\
         _typed_chan_demo\
         _typed_chan_send\
         _typed_chan_recv\
+        _chan_dag_supervisor_demo\
 
 ifeq ($(ARCH),x86_64)
 UPROGS := $(filter-out _usertests,$(UPROGS))

--- a/README
+++ b/README
@@ -160,6 +160,18 @@ serialized when sending.  Building with ``make`` will compile
 generated, run ``typed_chan_demo`` inside QEMU to see a Cap'n Proto
 message sent and received through the typed channel API.
 
+USER DEMO: CHANNELS, DAG SCHEDULER AND SUPERVISOR
+-------------------------------------------------
+``chan_dag_supervisor_demo`` combines typed channels, the DAG scheduler and
+the supervisor helper.  Building the repository with ``make`` compiles the
+demo and its helper ``typed_chan_recv``.  After booting with ``make qemu-nox``
+run::
+
+    $ chan_dag_supervisor_demo
+
+It spawns ``typed_chan_recv`` via ``driver_spawn``, sends a typed ping
+message, and yields through the DAG stream before exiting.
+
 DRIVER SUPERVISOR
 -----------------
 ``rcrs`` is a small supervisor that keeps user-space drivers running.

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -92,20 +92,31 @@ exo_unbind_page(page);
   `target`.  Cooperative schedulers store contexts in user space and
   resume them with this call.
 
+The scheduler iterates over tasks through the **exo_stream** callbacks
+`exo_stream_yield()` and `exo_stream_halt()`.  Schedulers such as the DAG
+engine register their `struct exo_sched_ops` with
+`exo_stream_register()` so the kernel can invoke the appropriate logic
+whenever the current task yields or no runnable work remains.
+
 ### IPC
 
 - `exo_send(dest, buf, len)` – enqueue a message to the destination
   capability.
 - `exo_recv(src, buf, len)` – receive data from the source capability.
+- `zipc_call(msg)` – perform a fast IPC syscall using the `zipc_msg_t`
+  structure defined in `ipc.h`.
+
+Typed channels built with the `CHAN_DECLARE` macro wrap these primitives
+and automatically serialize Cap'n Proto messages.
 
 The libOS builds higher level abstractions such as processes and files
 by combining these primitives.
 
 ## Running the Demos
 
-Two small user programs demonstrate the capability API.  After building
-the repository the filesystem image contains `exo_stream_demo` and
-`dag_demo`.
+Several user programs demonstrate the capability API.  After building
+the repository the filesystem image contains `exo_stream_demo`,
+`dag_demo`, `typed_chan_demo` and `chan_dag_supervisor_demo`.
 
 1. Build everything:
 
@@ -119,11 +130,13 @@ the repository the filesystem image contains `exo_stream_demo` and
    make qemu-nox
    ```
 
-3. At the xv6 shell run either demo:
+3. At the xv6 shell run one of the demos:
 
    ```
    $ exo_stream_demo
    $ dag_demo
+   $ typed_chan_demo
+   $ chan_dag_supervisor_demo
    ```
 
 Both programs print messages from their stub implementations showing how

--- a/src-uland/user/chan_dag_supervisor_demo.c
+++ b/src-uland/user/chan_dag_supervisor_demo.c
@@ -1,0 +1,54 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+#include "dag.h"
+#include "libos/driver.h"
+#include "proto/driver.capnp.h"
+
+CHAN_DECLARE(ping_chan, DriverPing);
+
+static ping_chan_t *c;
+static struct dag_node send_node, recv_node;
+
+static void send_task(void)
+{
+    DriverPing m = { .value = 42 };
+    exo_cap cap = {0};
+    ping_chan_send(c, cap, &m);
+    printf(1, "sent ping\n");
+}
+
+static void recv_task(void)
+{
+    DriverPing out = {0};
+    exo_cap cap = {0};
+    ping_chan_recv(c, cap, &out);
+    printf(1, "received %d\n", out.value);
+}
+
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    char *rargv[] = {"typed_chan_recv", 0};
+    int pid = driver_spawn("typed_chan_recv", rargv);
+
+    dag_sched_init();
+    c = ping_chan_create();
+
+    dag_node_init(&send_node, (exo_cap){0});
+    dag_node_init(&recv_node, (exo_cap){0});
+    dag_node_add_dep(&send_node, &recv_node);
+
+    dag_sched_submit(&send_node);
+    dag_sched_submit(&recv_node);
+
+    send_task();
+    recv_task();
+    exo_stream_yield();
+
+    kill(pid);
+    wait();
+
+    ping_chan_destroy(c);
+    exit();
+}


### PR DESCRIPTION
## Summary
- document fast IPC and exo_stream scheduler hooks in `phoenixkernel.md`
- list all available demos and add new combined demo
- add `chan_dag_supervisor_demo` user program showing typed channels, DAG scheduler and supervisor usage
- mention new demo in `README`
- build rules for the new program

## Testing
- `make -j$(nproc)` *(fails: conflicting types for syscall and struct trapframe fields)*