### PR TITLE
Add Phoenix examples

### DIFF
--- a/README
+++ b/README
@@ -213,7 +213,9 @@ empty.
 
 
 
-See doc/phoenixkernel.md for a design overview of the Phoenix exokernel.
+See doc/phoenixkernel.md for a design overview of the Phoenix exokernel
+and step-by-step examples of capability allocation, typed channels and
+driver management.
 
 Example supervisor usage to manage drivers:
 

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -236,3 +236,74 @@ int driver_connect(int pid, exo_cap ep);
 `driver_spawn` forks and executes the given program while
 `driver_connect` sends an endpoint capability to an already running
 driver.
+
+## Step-by-Step Examples
+
+The following walkthroughs illustrate how common Phoenix primitives fit
+together.  Each snippet can be compiled as a standalone program and run
+inside the xv6 environment.
+
+### Capability Allocation
+
+1. Allocate a physical page and map it in user space.
+2. Use the memory and then release the capability.
+
+```c
+#include "caplib.h"
+#include "user.h"
+
+int
+main(void)
+{
+    exo_cap page = exo_alloc_page();
+    void *va = map_page(page.id); // provided by the libOS
+    memset(va, 0, PGSIZE);
+    exo_unbind_page(page);
+    return 0;
+}
+```
+
+### Typed Channel Example
+
+1. Declare a typed channel using `CHAN_DECLARE`.
+2. Send a Cap'n Proto message and wait for the reply.
+
+```c
+#include "chan.h"
+#include "proto/ping.capnp.h"
+
+CHAN_DECLARE(ping_chan, ping_MESSAGE_SIZE);
+
+int
+main(void)
+{
+    struct ping msg = ping_init();
+    ping_chan_send(&ping_chan, &msg);
+    ping_chan_recv(&ping_chan, &msg);
+    return 0;
+}
+```
+
+### Driver Management Example
+
+1. Spawn a driver process with `driver_spawn`.
+2. Connect to its endpoint and exchange a test message.
+
+```c
+#include "libos/driver.h"
+
+int
+main(void)
+{
+    int pid = driver_spawn("blk_driver", 0);
+    exo_cap ep = obtain_driver_ep(pid); // helper returning the endpoint
+    driver_connect(pid, ep);
+    return 0;
+}
+```
+
+## Beatty Scheduler and Affine Runtime
+
+Work is underway on a Beatty scheduler that enables affine scheduling of
+tasks.  Once the implementation lands this section will describe its API
+and how the affine runtime integrates with existing DAG scheduling.


### PR DESCRIPTION
## Summary
- add example walkthroughs for Phoenix capabilities, typed channels and driver management
- mention Beatty scheduler placeholder
- reference new examples from README

## Testing
- `pre-commit run --files README doc/phoenixkernel.md` *(fails: command not found)*