### PR TITLE
Add affine runtime with lambda support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,9 +236,10 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/math_core.o \
        $(ULAND_DIR)/libos/sched.o \
         $(LIBOS_DIR)/fs.o \
-        $(LIBOS_DIR)/file.o \
-        $(LIBOS_DIR)/driver.o \
-        $(LIBOS_DIR)/posix.o
+       $(LIBOS_DIR)/file.o \
+       $(LIBOS_DIR)/driver.o \
+        $(LIBOS_DIR)/affine_runtime.o \
+       $(LIBOS_DIR)/posix.o
 
 
 libos: libos.a

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -1,14 +1,28 @@
-# Phoenix Kernel Overview
+#Phoenix Kernel Overview
 
-The Phoenix kernel implements an exokernel research platform built on top of the xv6 code base. Its goal is to expose low-level hardware resources directly to user space while keeping the in-kernel portion as small as possible. Applications link against a library operating system (libOS) that provides traditional services on top of the primitive capability interface.
+The Phoenix kernel implements an exokernel research platform built on top of the
+        xv6 code base.Its goal is to expose low -
+    level hardware resources directly to user space while keeping the in -
+    kernel portion as small as possible.Applications
+        link against a library operating
+        system(libOS)
+that provides traditional services on top of the primitive capability interface.
 
-## Exokernel Philosophy
+    ##Exokernel Philosophy
 
-Phoenix follows the exokernel approach: the kernel multiplexes hardware resources and enforces protection but leaves higher-level abstractions to user-level code. Instead of implementing full POSIX semantics in the kernel, Phoenix exposes capabilities that grant controlled access to memory regions, devices and communication endpoints. User-space runtimes build whatever abstractions they require.
+        Phoenix follows the exokernel approach
+    : the kernel multiplexes hardware resources and
+          enforces protection but leaves higher -
+    level abstractions to user -
+    level code.Instead of implementing full POSIX semantics in the kernel,
+    Phoenix exposes capabilities that grant controlled access to memory regions,
+    devices and communication endpoints.User -
+        space runtimes build whatever abstractions they require.
 
-## DAG Execution Model
+        ##DAG Execution Model
 
-Scheduling is expressed as a directed acyclic graph (DAG) of tasks. Nodes represent units of work and edges encode explicit dependencies. The kernel traverses this graph whenever a context switch is required, allowing cooperative libraries to chain execution without relying on heavyweight kernel threads. The DAG model enables fine-grained scheduling, efficient data-flow processing and transparent composition of user-level schedulers.
+            Scheduling is expressed as a directed acyclic
+            graph(DAG) of tasks. Nodes represent units of work and edges encode explicit dependencies. The kernel traverses this graph whenever a context switch is required, allowing cooperative libraries to chain execution without relying on heavyweight kernel threads. The DAG model enables fine-grained scheduling, efficient data-flow processing and transparent composition of user-level schedulers.
 
 ## Capability System
 
@@ -208,14 +222,14 @@ A minimal block driver illustrating these APIs is shown below:
 #include "user.h"
 
 int main(void) {
-    struct exo_blockcap blk;
-    fs_alloc_block(1, EXO_RIGHT_R | EXO_RIGHT_W, &blk);
-    char buf[BSIZE] = "Phoenix";
-    fs_write_block(blk, buf);
-    memset(buf, 0, sizeof(buf));
-    fs_read_block(blk, buf);
-    printf(1, "driver read: %s\n", buf);
-    return 0;
+  struct exo_blockcap blk;
+  fs_alloc_block(1, EXO_RIGHT_R | EXO_RIGHT_W, &blk);
+  char buf[BSIZE] = "Phoenix";
+  fs_write_block(blk, buf);
+  memset(buf, 0, sizeof(buf));
+  fs_read_block(blk, buf);
+  printf(1, "driver read: %s\n", buf);
+  return 0;
 }
 ```
 
@@ -236,3 +250,39 @@ int driver_connect(int pid, exo_cap ep);
 `driver_spawn` forks and executes the given program while
 `driver_connect` sends an endpoint capability to an already running
 driver.
+
+### Affine Runtime
+
+The libOS offers an **affine runtime** for experimenting with linear
+resource tracking.  An affine channel may be used at most once for
+sending and once for receiving.  The helper functions declared in
+`libos/affine_runtime.h` mirror the generic channel API but enforce the
+single-use property:
+
+```c
+affine_chan_t *affine_chan_create(const struct msg_type_desc *desc);
+void affine_chan_destroy(affine_chan_t *c);
+int affine_chan_send(affine_chan_t *c, exo_cap dest,
+                     const void *msg, size_t len);
+int affine_chan_recv(affine_chan_t *c, exo_cap src,
+                     void *msg, size_t len);
+```
+
+Lambda terms are represented by `lambda_term_t` and executed with
+`lambda_run()` which deducts a unit of fuel for every evaluation step:
+
+```c
+typedef int (*lambda_fn)(void *env);
+
+typedef struct lambda_term {
+  lambda_fn fn; // one step evaluator
+  void *env;    // closure environment
+  int steps;    // total steps executed
+} lambda_term_t;
+
+int lambda_run(lambda_term_t *t, int fuel);
+```
+
+This lightweight accounting mechanism allows research into affine
+λ-calculus interpreters while integrating with Phoenix's typed channel
+infrastructure.

--- a/libos/affine_runtime.c
+++ b/libos/affine_runtime.c
@@ -1,0 +1,50 @@
+#include "affine_runtime.h"
+#include "ulib.h" // for malloc/free
+
+// Allocate an affine channel
+affine_chan_t *affine_chan_create(const struct msg_type_desc *desc) {
+  affine_chan_t *c = malloc(sizeof(affine_chan_t));
+  if (c) {
+    c->base.desc = desc;
+    c->base.msg_size = msg_desc_size(desc);
+    c->used_send = 0;
+    c->used_recv = 0;
+  }
+  return c;
+}
+
+// Destroy an affine channel
+void affine_chan_destroy(affine_chan_t *c) { free(c); }
+
+// Send once through the channel
+int affine_chan_send(affine_chan_t *c, exo_cap dest, const void *msg,
+                     size_t len) {
+  if (!c || c->used_send)
+    return -1;
+  int r = chan_endpoint_send(&c->base, dest, msg, len);
+  if (r == 0)
+    c->used_send = 1;
+  return r;
+}
+
+// Receive once through the channel
+int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg, size_t len) {
+  if (!c || c->used_recv)
+    return -1;
+  int r = chan_endpoint_recv(&c->base, src, msg, len);
+  if (r == 0)
+    c->used_recv = 1;
+  return r;
+}
+
+// Execute a lambda term with resource accounting
+int lambda_run(lambda_term_t *t, int fuel) {
+  if (!t || !t->fn)
+    return -1;
+  int ret = 0;
+  while (fuel-- > 0 && ret == 0) {
+    ret = t->fn(t->env);
+    t->steps++;
+  }
+  return ret;
+}

--- a/libos/affine_runtime.h
+++ b/libos/affine_runtime.h
@@ -1,0 +1,55 @@
+#pragma once
+#include "chan.h"
+#include "caplib.h"
+
+// Affine channel wrapper allowing at most one send and one receive
+typedef struct affine_chan {
+  chan_t base;
+  int used_send;
+  int used_recv;
+} affine_chan_t;
+
+affine_chan_t *affine_chan_create(const struct msg_type_desc *desc);
+void affine_chan_destroy(affine_chan_t *c);
+int affine_chan_send(affine_chan_t *c, exo_cap dest, const void *msg,
+                     size_t len);
+int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg, size_t len);
+
+// Simple lambda term representation
+typedef int (*lambda_fn)(void *env);
+
+typedef struct lambda_term {
+  lambda_fn fn; // one evaluation step
+  void *env;    // closure environment
+  int steps;    // total steps executed
+} lambda_term_t;
+
+// Run the lambda term for up to `fuel` steps. The function returns
+// the value returned by the underlying lambda function on the last
+// step (0 for continue, non-zero to stop).
+int lambda_run(lambda_term_t *t, int fuel);
+
+// Macro to declare an affine typed channel using Cap'n Proto helpers
+#define AFFINE_CHAN_DECLARE(name, type)                                        \
+  static const struct msg_type_desc name##_typedesc = {type##_MESSAGE_SIZE};   \
+  typedef struct {                                                             \
+    affine_chan_t base;                                                        \
+  } name##_t;                                                                  \
+  static inline name##_t *name##_create(void) {                                \
+    return (name##_t *)affine_chan_create(&name##_typedesc);                   \
+  }                                                                            \
+  static inline void name##_destroy(name##_t *c) {                             \
+    affine_chan_destroy(&c->base);                                             \
+  }                                                                            \
+  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    type##_encode(m, buf);                                                     \
+    return affine_chan_send(&c->base, dest, buf, type##_MESSAGE_SIZE);         \
+  }                                                                            \
+  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    int r = affine_chan_recv(&c->base, src, buf, type##_MESSAGE_SIZE);         \
+    if (r == 0)                                                                \
+      type##_decode(m, buf);                                                   \
+    return r;                                                                  \
+  }


### PR DESCRIPTION
## Summary
- implement `libos/affine_runtime.c` and matching header
- allow creation of affine typed channels and simple λ-term execution
- document the API in `doc/phoenixkernel.md`
- build new object as part of `libos`

## Testing
- `clang-format -i libos/affine_runtime.c libos/affine_runtime.h doc/phoenixkernel.md Makefile`
- `clang-tidy libos/affine_runtime.c -- -I.` *(fails: unknown key 'Standard')*
- `make libos` *(fails: No rule to make target 'src-uland/swtch.o')*