### PR TITLE
Add gas exhaustion handling

### DIFF
--- a/caplib.h
+++ b/caplib.h
@@ -13,6 +13,7 @@ int cap_recv(exo_cap src, void *buf, uint64 len);
 int cap_set_timer(void (*handler)(void));
 int cap_set_gas(uint64 amount);
 int cap_get_gas(void);
+int cap_out_of_gas(void);
 void cap_yield_to(context_t **old, context_t *target);
 int cap_yield_to_cap(exo_cap target);
 int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);

--- a/defs.h
+++ b/defs.h
@@ -197,7 +197,6 @@ int argstr(int, char **);
 int fetchint(uint, int *);
 int fetchstr(uint, char **);
 void syscall(void);
-         syscall(void);
 
 // timer.c
 void timerinit(void);

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -57,6 +57,7 @@ void trap(struct trapframe *tf) {
       if (myproc()->gas_remaining == 0) {
         myproc()->out_of_gas = 1;
         lapiceoi();
+        exo_stream_yield();
         yield();
         break;
       }

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -23,6 +23,7 @@ void cap_flush_block(exo_blockcap *cap, void *data) {
 int cap_set_timer(void (*handler)(void)) { return set_timer_upcall(handler); }
 int cap_set_gas(uint64 amount) { return set_gas(amount); }
 int cap_get_gas(void) { return get_gas(); }
+int cap_out_of_gas(void) { return get_gas() <= 0; }
 
 void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);

--- a/src-uland/libos/sched.c
+++ b/src-uland/libos/sched.c
@@ -15,13 +15,13 @@ void sched_add(exo_cap cap) {
 static void sched_tick(void) {
     if(nprocs == 0)
         return;
-    if(get_gas() > 0)
+    if(!cap_out_of_gas())
         return;
     for(int i = 0; i < nprocs; i++) {
         cur = (cur + 1) % nprocs;
         set_gas(GAS_SLICE);
         cap_yield_to_cap(runq[cur]);
-        if(get_gas() > 0)
+        if(!cap_out_of_gas())
             break;
     }
 }


### PR DESCRIPTION
## Summary
- decrement gas each tick and yield via exo_stream_yield when empty
- expose new `cap_out_of_gas()` utility
- use `cap_out_of_gas()` in userland scheduler
- tidy stray definition in `defs.h`

## Testing
- `make check`
- `make ARCH=i386` *(fails: `i386:x86-64 architecture of input file`)*