### PR TITLE
Ensure pre-commit is installed and hooks enabled

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,6 +49,9 @@ pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 
+# Ensure pre-commit is available even if the apt package fails
+pip3 install --no-cache-dir pre-commit
+
 #— QEMU emulation for foreign binaries
 for pkg in \
   qemu-user-static \
@@ -146,6 +149,11 @@ rm /tmp/protoc.zip
 
 #— gmake alias
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
+
+# Install pre-commit hooks if possible
+if command -v pre-commit >/dev/null 2>&1; then
+  pre-commit install >/dev/null 2>&1 || true
+fi
 
 #— clean up
 apt-get clean


### PR DESCRIPTION
## Summary
- install pre-commit via pip in `setup.sh`
- install hooks automatically if pre-commit is available

## Testing
- `make check`
- `pre-commit run --files setup.sh` *(fails: command not found)*