### PR TITLE
Fix setup script to install pre-commit

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ apt-get update -y
 #— core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig \
+  clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \


### PR DESCRIPTION
## Summary
- ensure `pre-commit` is installed via apt

## Testing
- `make clean`
- `make` *(fails: error: conflicting types for `syscall`)*