### PR TITLE
Add shellcheck and Python hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,18 @@ repos:
       language: system
       pass_filenames: true
       types: [cpp, cxx, cc, c++, hpp, hxx, hh]
+    - id: shellcheck
+      name: shellcheck
+      entry: shellcheck
+      language: system
+      types: [shell]
+    - id: black
+      name: black
+      entry: black --check --diff
+      language: system
+      types: [python]
+    - id: flake8
+      name: flake8
+      entry: flake8
+      language: system
+      types: [python]

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ apt-get update -y
 #— core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig \
+  clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig shellcheck \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
@@ -53,7 +53,8 @@ done
 
 pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
-  tensorflow-model-optimization mlflow onnxruntime-tools
+  tensorflow-model-optimization mlflow onnxruntime-tools \
+  black flake8
 
 # Fallback to pip if pre-commit is still missing
 if ! command -v pre-commit >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- enforce shell scripts via shellcheck
- format and lint Python via black and flake8
- ensure setup installs shellcheck, black and flake8
- keep pre-commit installation after tool setup

## Testing
- `python3 -m py_compile scripts/generate_dag.py`
- `bash -n qemu-aarch64.sh`
- `bash -n scripts/mock_capnpc.sh`
- `bash -n setup.sh`
- `apt-get update` *(fails: Could not connect to proxy)*