### PR TITLE
Add Swift example

### DIFF
--- a/README
+++ b/README
@@ -224,3 +224,15 @@ $ supervisor start blk_driver
 ... later ...
 $ supervisor restart blk_driver
 ```
+
+SWIFT EXAMPLE
+-------------
+A small Swift demo is available in the ``swift`` directory. The script
+``swift/build_swift.sh`` compiles and runs ``hello.swift``.
+Execute it from the repository root:
+
+```
+$ ./swift/build_swift.sh
+```
+
+It should print ``Hello, world!``.

--- a/swift/build_swift.sh
+++ b/swift/build_swift.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compile the Swift program and run it
+swiftc "$(dirname "$0")/hello.swift" -o "$(dirname "$0")/hello"
+"$(dirname "$0")/hello"

--- a/swift/hello.swift
+++ b/swift/hello.swift
@@ -1,0 +1,1 @@
+print("Hello, world!")


### PR DESCRIPTION
## Summary
- add `swift/hello.swift` demo program
- add `swift/build_swift.sh` helper script to compile and run the Swift demo
- document usage in new "Swift example" section of the README

## Testing
- `./swift/build_swift.sh`