### PR TITLE
Add Swift libFuzzer example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ libos.a
 kernelmemfs
 mkfs
 .gdbinit
+fuzz

--- a/fuzz.swift
+++ b/fuzz.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@_cdecl("LLVMFuzzerTestOneInput")
+public func fuzz(_ ptr: UnsafePointer<UInt8>?, _ size: Int) -> Int32 {
+    guard let ptr = ptr else { return 0 }
+    let data = Data(bytes: ptr, count: size)
+    if data == Data("crash".utf8) {
+        fatalError("crash triggered")
+    }
+    return 0
+}

--- a/scripts/swift_fuzz.py
+++ b/scripts/swift_fuzz.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Build and run the Swift libFuzzer target."""
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def build_fuzzer(root: Path) -> Path:
+    src = root / "fuzz.swift"
+    out = root / "fuzz"
+    cmd = [
+        "swiftc",
+        "-sanitize=fuzzer,address",
+        "-parse-as-library",
+        str(src),
+        "-o",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+    return out
+
+
+def run_fuzzer(executable: Path, args):
+    subprocess.run([str(executable), *args], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Swift libFuzzer helper")
+    parser.add_argument(
+        "fuzzer_args", nargs=argparse.REMAINDER, help="Arguments for the fuzzer"
+    )
+    opts = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    exe = build_fuzzer(root)
+    run_fuzzer(exe, opts.fuzzer_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.sh
+++ b/setup.sh
@@ -114,7 +114,8 @@ for pkg in \
   ldc gdc dmd-compiler dub libphobos-dev \
   chicken-bin libchicken-dev chicken-doc \
   openjdk-17-jdk maven gradle dotnet-sdk-8 mono-complete \
-  swift swift-lldb swiftpm kotlin gradle-plugin-kotlin \
+  swift swift-lldb swiftpm swift-tools-support-core libswiftFuzzer \
+  kotlin gradle-plugin-kotlin \
   ruby ruby-dev gem bundler php-cli php-dev composer phpunit \
   r-base r-base-dev dart flutter gnat gprbuild gfortran gnucobol \
   fpc lazarus zig nim nimble crystal shards gforth; do


### PR DESCRIPTION
## Summary
- create a simple Swift fuzz target using libFuzzer integration
- add Python helper script to build and run the Swift fuzz target
- ignore the generated fuzz binary
- install required Swift fuzzing packages in `setup.sh`

## Testing
- `python3 scripts/swift_fuzz.py --help`
- `python3 scripts/swift_fuzz.py -- -runs=1`
