### PR TITLE
Validate typed channel message sizes

### DIFF
--- a/chan.h
+++ b/chan.h
@@ -14,7 +14,9 @@ chan_t *chan_create(const struct msg_type_desc *desc);
 // Free a channel allocated with chan_create
 void chan_destroy(chan_t *c);
 
-// Send and receive through an exo capability endpoint
+// Send and receive through an exo capability endpoint.  The helpers
+// validate that the caller supplied length matches `c->msg_size` and
+// print an error to fd 2 when it does not.
 int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len);
 int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len);
 

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -193,6 +193,17 @@ and the corresponding `type_encode`/`type_decode` helpers.  A typed channel
 uses these helpers to serialize exactly `msg_size` bytes when interacting
 with an endpoint.  See `typed_chan_demo.c` for an example.
 
+#### Typed Channel Semantics
+
+Each channel instance stores the expected Cap'n Proto message size in its
+descriptor.  The generic helpers `chan_endpoint_send` and
+`chan_endpoint_recv` verify that the caller supplied buffer length matches
+this `msg_size`.  On a mismatch the helpers print a diagnostic to file
+descriptor 2 and return `-1` without transmitting data.  Channels declared
+via `CHAN_DECLARE` automatically populate the descriptor with the
+`type_MESSAGE_SIZE` constant generated from the schema, so typical user code
+benefits from this runtime validation without manually passing sizes.
+
 ## libOS APIs
 
 The libOS includes wrappers around the capability syscalls as well as helper

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -22,16 +22,20 @@ chan_destroy(chan_t *c)
 int
 chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len)
 {
-    if(len != c->msg_size)
+    if(len != c->msg_size){
+        printf(2, "chan_endpoint_send: size %d expected %d\n", len, c->msg_size);
         return -1;
+    }
     return cap_send(dest, msg, c->msg_size);
 }
 
 int
 chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len)
 {
-    if(len != c->msg_size)
+    if(len != c->msg_size){
+        printf(2, "chan_endpoint_recv: size %d expected %d\n", len, c->msg_size);
         return -1;
+    }
     return cap_recv(src, msg, c->msg_size);
 }
 

--- a/src-uland/user/typed_chan_demo.c
+++ b/src-uland/user/typed_chan_demo.c
@@ -21,6 +21,8 @@ main(int argc, char *argv[])
     char bad[1] = {0};
     int r = chan_endpoint_send(&c->base, cap, bad, sizeof(bad));
     printf(1, "bad send result %d\n", r);
+    r = chan_endpoint_recv(&c->base, cap, bad, sizeof(bad));
+    printf(1, "bad recv result %d\n", r);
     ping_chan_destroy(c);
     exit();
 }


### PR DESCRIPTION
## Summary
- describe typed channel semantics in docs
- validate message size in chan_endpoint_send/recv
- showcase validation in typed_chan_demo

## Testing
- `make ARCH=x86_64` *(fails: conflicting types for `syscall`)*