### PR TITLE
Enable per-driver timeouts in rcrs

### DIFF
--- a/doc/rcrs.md
+++ b/doc/rcrs.md
@@ -6,9 +6,9 @@ arguments. Lines beginning with `#` are treated as comments and ignored.
 
 Optional flags can follow the command. The current flags are:
 
-* `--timeout=<ticks>` – number of clock ticks to wait for a driver to
-  respond to a ping before restarting it. If omitted, a default timeout
-  twice the ping interval is used.
+* `--timeout=<ticks>` or `--ping-timeout=<ticks>` – number of clock
+  ticks to wait for a driver to respond to a ping before restarting it.
+  If omitted, a default timeout twice the ping interval is used.
 
 Example `drivers.conf`:
 
@@ -21,4 +21,6 @@ pingdriver --timeout=60
 ```
 
 The supervisor periodically prints a status report showing each driver's
-process ID and how many times it has been restarted.
+process ID and how many times it has been restarted. This restart count is
+tracked for each driver since the supervisor started and increases every time
+`rcrs` relaunches the program.

--- a/drivers.conf
+++ b/drivers.conf
@@ -1,2 +1,5 @@
+# launch the keyboard service
 kbdserv
-pingdriver
+
+# network driver with a custom ping timeout
+pingdriver --timeout=60

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -88,6 +88,8 @@ static int parse_config(const char *path, struct driver *d, int max) {
 
         if (starts_with(tok, "--timeout="))
           d[idx].ping_timeout = atoi(tok + 10);
+        else if (starts_with(tok, "--ping-timeout="))
+          d[idx].ping_timeout = atoi(tok + 15);
         else
           d[idx].argv[arg++] = tok;
       }


### PR DESCRIPTION
## Summary
- support `--ping-timeout=` flag in `drivers.conf`
- document timeout flag alias and restart count behaviour
- show example timeout flag in the default config

## Testing
- `make -j$(nproc)` *(fails: data definition has no type or storage class)*