### PR TITLE
Add extended POSIX wrappers and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ UPROGS=\
         _typed_chan_recv\
         _chan_dag_supervisor_demo\
         _libos_posix_test\
+        _libos_posix_ext_test\
 
 
 ifeq ($(ARCH),x86_64)

--- a/libos/posix.h
+++ b/libos/posix.h
@@ -1,8 +1,16 @@
 #pragma once
 #include "types.h"
 
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
 int libos_open(const char *path, int flags);
 int libos_read(int fd, void *buf, size_t n);
 int libos_write(int fd, const void *buf, size_t n);
 int libos_close(int fd);
 int libos_spawn(const char *path, char *const argv[]);
+int libos_fstat(int fd, struct stat *st);
+int libos_stat(const char *path, struct stat *st);
+int libos_unlink(const char *path);
+int libos_lseek(int fd, size_t off, int whence);

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -1,8 +1,16 @@
 #pragma once
 #include "types.h"
 
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
 int libos_open(const char *path, int flags);
 int libos_read(int fd, void *buf, size_t n);
 int libos_write(int fd, const void *buf, size_t n);
 int libos_close(int fd);
 int libos_spawn(const char *path, char *const argv[]);
+int libos_fstat(int fd, struct stat *st);
+int libos_stat(const char *path, struct stat *st);
+int libos_unlink(const char *path);
+int libos_lseek(int fd, size_t off, int whence);

--- a/src-uland/libos_posix_ext_test.c
+++ b/src-uland/libos_posix_ext_test.c
@@ -1,0 +1,49 @@
+#include "libos/posix.h"
+#include "user.h"
+#include "string.h"
+
+int main(void) {
+    const char *name = "extfile";
+    int fd = libos_open(name, 0);
+    if(fd < 0){
+        printf(1, "ext_test: open failed\n");
+        exit();
+    }
+    const char *msg = "abcdef";
+    if(libos_write(fd, msg, strlen(msg)) != (int)strlen(msg)){
+        printf(1, "ext_test: write failed\n");
+        exit();
+    }
+    if(libos_lseek(fd, 0, 0) < 0){
+        printf(1, "ext_test: lseek failed\n");
+        exit();
+    }
+    char buf[8];
+    int n = libos_read(fd, buf, sizeof(buf));
+    if(n != (int)strlen(msg) || memcmp(buf, msg, strlen(msg)) != 0){
+        printf(1, "ext_test: read mismatch\n");
+        exit();
+    }
+    struct stat st;
+    if(libos_fstat(fd, &st) < 0){
+        printf(1, "ext_test: fstat failed\n");
+        exit();
+    }
+    libos_close(fd);
+
+    if(libos_stat(name, &st) < 0){
+        printf(1, "ext_test: stat failed\n");
+        exit();
+    }
+    if(libos_unlink(name) < 0){
+        printf(1, "ext_test: unlink failed\n");
+        exit();
+    }
+    if(libos_stat(name, &st) >= 0){
+        printf(1, "ext_test: file still exists\n");
+        exit();
+    }
+
+    printf(1, "libos_posix_ext_test passed\n");
+    exit();
+}


### PR DESCRIPTION
## Summary
- extend libOS POSIX wrappers with stat, fstat, unlink, and lseek
- export new APIs via headers
- add SEEK_* macros
- add user test exercising the extended wrappers

## Testing
- `make _libos_posix_ext_test` *(fails: No rule to make target 'src-uland/swtch.o', needed by 'libos.a')*
- `make` *(fails: error in src-kernel/bio.c about syscall)*