### PR TITLE
Update scheduling docs and add combined demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,9 @@ $(ULAND_DIR)/beatty_demo.o: $(ULAND_DIR)/user/beatty_demo.c
 
 $(ULAND_DIR)/typed_chan_recv.o: $(ULAND_DIR)/user/typed_chan_recv.c
 	$(CC) $(CFLAGS) -c -o $@ $<
-
 $(ULAND_DIR)/chan_dag_supervisor_demo.o: $(ULAND_DIR)/user/chan_dag_supervisor_demo.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+$(ULAND_DIR)/chan_beatty_rcrs_demo.o: $(ULAND_DIR)/user/chan_beatty_rcrs_demo.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 	# Generate simple C bindings from Cap'n Proto schemas
@@ -323,6 +324,7 @@ UPROGS=\
         _typed_chan_send\
         _typed_chan_recv\
         _chan_dag_supervisor_demo\
+        _chan_beatty_rcrs_demo\
         _libos_posix_test\
 
 

--- a/README
+++ b/README
@@ -172,6 +172,29 @@ run::
 It spawns ``typed_chan_recv`` via ``driver_spawn``, sends a typed ping
 message, and yields through the DAG stream before exiting.
 
+
+USER DEMO: BEATTY SCHEDULER
+--------------------------
+``beatty_demo`` exercises the kernel's Beatty scheduler and prints the
+resulting task order. Build with ``make`` so the binary is placed in
+``fs.img`` and run it inside QEMU:
+
+    $ beatty_demo
+
+USER DEMO: HELLO CHANNEL
+------------------------
+``hello_channel`` shows typed channels together with capability
+borrowing. After ``make`` completes, boot with ``make qemu-nox`` and run:
+
+    $ hello_channel
+
+USER DEMO: CHANNELS, BEATTY SCHEDULER AND RCRS
+----------------------------------------------
+``chan_beatty_rcrs_demo`` combines typed channels with the Beatty
+scheduler and relies on ``rcrs`` to restart the helper process if it
+exits. Build the repository and execute the demo after booting:
+
+    $ chan_beatty_rcrs_demo
 DRIVER SUPERVISOR
 -----------------
 ``rcrs`` is a small supervisor that keeps user-space drivers running.

--- a/src-uland/user/chan_beatty_rcrs_demo.c
+++ b/src-uland/user/chan_beatty_rcrs_demo.c
@@ -1,0 +1,48 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+#include "libos/driver.h"
+#include "proto/driver.capnp.h"
+
+CHAN_DECLARE(ping_chan, DriverPing);
+
+static ping_chan_t *c;
+
+static void send_task(void)
+{
+    DriverPing m = { .value = 73 };
+    exo_cap cap = {0};
+    ping_chan_send(c, cap, &m);
+    printf(1, "beatty send\n");
+}
+
+static void recv_task(void)
+{
+    DriverPing out = {0};
+    exo_cap cap = {0};
+    ping_chan_recv(c, cap, &out);
+    printf(1, "beatty recv %d\n", out.value);
+}
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    char *rargv[] = {"typed_chan_recv", 0};
+    int pid = driver_spawn("typed_chan_recv", rargv);
+
+    c = ping_chan_create();
+
+    beatty_sched_set_tasks((exo_cap){0}, (exo_cap){0});
+
+    send_task();
+    exo_stream_yield();
+    recv_task();
+    exo_stream_yield();
+
+    kill(pid);
+    wait();
+
+    ping_chan_destroy(c);
+    exit();
+}


### PR DESCRIPTION
## Summary
- document Beatty scheduler and new rcrs features
- describe Beatty, hello channel and Beatty+rcrs demos
- add `chan_beatty_rcrs_demo` example
- hook demo into build

## Testing
- `make` *(fails: conflicting types for `syscall`)*