### PR TITLE
Add ISA build script and CPU optimization flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ endif
 
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
-ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide -I. -Isrc-headers -I$(KERNEL_DIR) -I$(ULAND_DIR) -Iproto
+# Optional CPU optimization flags
+CFLAGS += $(CPUFLAGS)
+ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide -I. -Isrc-headers -I$(KERNEL_DIR) -I$(ULAND_DIR) -Iproto $(CPUFLAGS)
 
 	#Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)

--- a/scripts/build_isa_variants.sh
+++ b/scripts/build_isa_variants.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build xv6 for multiple x86 CPU feature sets.
+# The Makefile accepts CPUFLAGS to extend compiler and assembler flags.
+
+ARCH=${ARCH:-x86_64}
+MAKECMD=${MAKECMD:-make}
+
+# Map variant name -> CPUFLAGS
+declare -A ISA_FLAGS=(
+  [baseline]=""
+  [x87]="-mfpmath=387"
+  [mmx]="-mmmx"
+  [sse]="-msse"
+  [sse2]="-msse2"
+  [sse3]="-msse3"
+  [ssse3]="-mssse3"
+  [sse4.1]="-msse4.1"
+  [sse4.2]="-msse4.2"
+  [avx]="-mavx"
+  [avx2]="-mavx2"
+  [fma]="-mfma"
+  [avx512]="-mavx512f -mavx512vl -mavx512bw"
+)
+
+outdir=build/isa
+mkdir -p "$outdir"
+
+for variant in "${!ISA_FLAGS[@]}"; do
+  echo "== Building $variant =="
+  flags="${ISA_FLAGS[$variant]}"
+  # Clean before each build to avoid mixing objects
+  $MAKECMD clean >/dev/null || true
+  CPUFLAGS="$flags" ARCH="$ARCH" $MAKECMD -j"$(nproc)" >/dev/null
+  mkdir -p "$outdir/$variant"
+  cp kernel* "$outdir/$variant/" 2>/dev/null || true
+  cp xv6*.img "$outdir/$variant/" 2>/dev/null || true
+  echo "Built $variant with flags: $flags" > "$outdir/$variant/build.info"
+done
+
+cat <<EOM
+All builds completed. Results stored in $outdir/.
+Each subdirectory contains the compiled kernel and disk images.
+EOM

--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,7 @@ done
 pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools \
-  black flake8
+  black flake8 pyperf py-cpuinfo
 
 # Fallback to pip if pre-commit is still missing
 if ! command -v pre-commit >/dev/null 2>&1; then
@@ -143,6 +143,12 @@ for pkg in \
   bochs bochs-sdl \
   gdb lldb perf gcovr lcov bcc-tools bpftrace \
   openmpi-bin libopenmpi-dev mpich; do
+  apt_pin_install "$pkg"
+done
+
+#— ISA optimization and benchmarking tools
+for pkg in \
+  nasm yasm cpuid msr-tools numactl oprofile libpfm4-dev; do
   apt_pin_install "$pkg"
 done
 # Ensure swiftc is available; install official Swift toolchain if missing


### PR DESCRIPTION
## Summary
- support CPUFLAGS in Makefile so users can pass ISA-specific options
- add `scripts/build_isa_variants.sh` helper to compile xv6 for x87, SSE, AVX etc
- extend setup script with benchmarking tools and Python packages for CPU analysis

## Testing
- `make clean >/dev/null && make qemu-nox QEMU=echo ARCH=x86_64` *(fails: No rule to make target 'fs.h')*
- `pre-commit run --files Makefile setup.sh scripts/build_isa_variants.sh` *(fails: pre-commit not found)*
