### PR TITLE
Add cross-compiling guide

### DIFF
--- a/README
+++ b/README
@@ -119,6 +119,37 @@ limit of usable physical memory.  When building for 64-bit these values
 are selected automatically via conditional compilation and replace the
 32-bit constants.
 
+CROSS-COMPILING
+---------------
+The ``setup.sh`` script installs cross-compilers for several
+architectures such as ARMv7, AArch64, PowerPC and PowerPC64 (both
+big-endian and little-endian).  Use the ``ARCH`` variable when invoking
+``make`` to select the desired target.  The current Makefile implements
+``ARCH=aarch64`` in addition to ``x86`` and ``x86_64``.
+
+Build and run an AArch64 image with::
+
+    make ARCH=aarch64
+    ./qemu-aarch64.sh
+
+Other cross-compilers are ready for experimentation.  Example commands
+for architectures that do not yet have dedicated run scripts are::
+
+    make ARCH=arm        # ARMv7
+    qemu-system-arm -M virt -nographic -kernel kernel-arm
+
+    make ARCH=powerpc    # 32-bit PowerPC
+    qemu-system-ppc -M g3beige -nographic -kernel kernel-powerpc
+
+    make ARCH=ppc64      # PowerPC64 big-endian
+    qemu-system-ppc64 -M pseries -nographic -kernel kernel-ppc64
+
+    make ARCH=ppc64le    # PowerPC64 little-endian
+    qemu-system-ppc64 -M pseries -cpu POWER8 -nographic -kernel kernel-ppc64le
+
+When additional ``ARCH`` values are implemented in the Makefile these
+commands will build and boot the corresponding images.
+
 MESON BUILD
 -----------
 The repository also includes a simple Meson setup.  After running


### PR DESCRIPTION
## Summary
- document how to build for `ARCH=aarch64`
- describe cross-compilers installed by `setup.sh`
- show sample commands for other architectures

## Testing
- `make clean`
- `make` *(fails: `kernel/exo_cpu.h` missing)*