### PR TITLE
Add minimal IA16 build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ CSTD ?= gnu2x
 CLANG_TIDY ?= clang-tidy
 TIDY_SRCS := $(wildcard $(KERNEL_DIR)/*.c $(ULAND_DIR)/*.c $(LIBOS_DIR)/*.c)
 
+ifeq ($(ARCH),ia16)
+TOOLPREFIX ?= ia16-elf-
+endif
+
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/main64.o $(KERNEL_DIR)/swtch64.o \
@@ -96,6 +100,10 @@ OBJS += $(KERNEL_DIR)/main64.o \
        $(KERNEL_DIR)/arch/aarch64/vectors.o
 BOOTASM := $(KERNEL_DIR)/arch/aarch64/boot.S
 ENTRYASM := $(KERNEL_DIR)/arch/aarch64/entry.S
+else ifeq ($(ARCH),ia16)
+OBJS += $(KERNEL_DIR)/vectors.o
+BOOTASM := $(KERNEL_DIR)/arch/ia16/boot.S
+ENTRYASM := $(KERNEL_DIR)/arch/ia16/entry.S
 else
 OBJS += $(KERNEL_DIR)/swtch.o \
        $(KERNEL_DIR)/vectors.o
@@ -128,6 +136,14 @@ KERNELMEMFS_FILE := kernelmemfs-aarch64
 FS_IMG := fs-aarch64.img
 XV6_IMG := xv6-aarch64.img
 XV6_MEMFS_IMG := xv6memfs-aarch64.img
+else ifeq ($(ARCH),ia16)
+ARCHFLAG := -m16
+LDFLAGS += -m elf_i386
+KERNEL_FILE := kernel-ia16
+KERNELMEMFS_FILE := kernelmemfs-ia16
+FS_IMG := fs-ia16.img
+XV6_IMG := xv6-ia16.img
+XV6_MEMFS_IMG := xv6memfs-ia16.img
 else
 ARCHFLAG := -m32
 LDFLAGS += -m elf_i386
@@ -150,10 +166,12 @@ endif
 
 
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto
+CFLAGS += $(if $(filter ia16,$(ARCH)),-I$(KERNEL_DIR)/arch/ia16,)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 # Optional CPU optimization flags
 CFLAGS += $(CPUFLAGS)
 ASFLAGS = $(ARCHFLAG) -gdwarf-2 -Wa,-divide -I. -Isrc-headers -I$(KERNEL_DIR) -I$(ULAND_DIR) -Iproto $(CPUFLAGS)
+ASFLAGS += $(if $(filter ia16,$(ARCH)),-I$(KERNEL_DIR)/arch/ia16,)
 
 	#Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)

--- a/README
+++ b/README
@@ -119,6 +119,18 @@ limit of usable physical memory.  When building for 64-bit these values
 are selected automatically via conditional compilation and replace the
 32-bit constants.
 
+16-BIT BUILD
+------------
+An experimental 16-bit configuration is also available.  ``setup.sh``
+installs the ``ia16-elf-gcc`` cross compiler.  Build the tiny 16-bit
+kernel and run it under Bochs with::
+
+    make ARCH=ia16
+    make bochs ARCH=ia16
+
+This creates ``kernel-ia16`` and ``xv6-ia16.img`` which Bochs can boot
+in real mode.
+
 MESON BUILD
 -----------
 The repository also includes a simple Meson setup.  After running

--- a/src-kernel/arch/ia16/boot.S
+++ b/src-kernel/arch/ia16/boot.S
@@ -1,0 +1,15 @@
+#include "asm.h"
+#include "memlayout.h"
+
+.code16
+.globl start
+start:
+  cli
+  xorw %ax, %ax
+  movw %ax, %ds
+  movw %ax, %es
+  movw %ax, %ss
+  movw $start, %sp
+  call bootmain
+1:
+  jmp 1b

--- a/src-kernel/arch/ia16/entry.S
+++ b/src-kernel/arch/ia16/entry.S
@@ -1,0 +1,13 @@
+#include "asm.h"
+#include "memlayout.h"
+#include "param.h"
+
+.code16
+.globl entry16
+entry16:
+  movw $(stack16 + KSTACKSIZE), %sp
+  call main
+1:
+  jmp 1b
+
+.comm stack16, KSTACKSIZE

--- a/src-kernel/arch/ia16/memlayout.h
+++ b/src-kernel/arch/ia16/memlayout.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Simplified memory layout for 16-bit real mode
+#define KERNBASE16 0x0000
+#define KERNLINK16 0x7C00
+#define PHYSTOP16 0x100000
+#define DEVSPACE16 0x100000


### PR DESCRIPTION
## Summary
- introduce `src-kernel/arch/ia16/` with simple 16‑bit startup code and memory layout
- extend `Makefile` to support `ARCH=ia16` using `ia16-elf-gcc`
- document how to build and boot the 16‑bit configuration under Bochs

## Testing
- `make check`
