### PR TITLE
Update Beatty DAG docs

### DIFF
--- a/README
+++ b/README
@@ -259,7 +259,9 @@ exits. Build the repository and execute the demo after booting:
 USER DEMO: BEATTY AND DAG
 -------------------------
 ``beatty_dag_demo`` composes the Beatty and DAG schedulers through a
-combined exo stream. Build with ``make`` and run inside QEMU::
+combined exo stream. The demo prints how Beatty selects which task family
+runs while the DAG scheduler walks the dependency graph for that family.
+Build with ``make`` and run inside QEMU::
 
     $ beatty_dag_demo
 DRIVER SUPERVISOR

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -365,3 +365,5 @@ main(void)
 
 The kernel now ships with a Beatty scheduler implementing an affine runtime. It dispatches multiple cooperating contexts according to irrational weights. Enable it with `beatty_sched_set_tasks` after registering the Beatty exo stream. Typed channels can exchange messages whenever the scheduler yields.
 
+When `beatty_dag_stream_init()` is invoked during boot the Beatty scheduler is chained with the DAG scheduler through a single exo stream. Beatty picks the next task family based on its irrational weights and then defers to the DAG scheduler to run the individual ready nodes. This allows user space runtimes to build dependency graphs while still benefiting from the affine time slicing provided by Beatty. Selecting the combined stream merely requires calling the initializer before submitting DAG nodes.
+

--- a/src-kernel/beatty_dag_stream.c
+++ b/src-kernel/beatty_dag_stream.c
@@ -2,6 +2,19 @@
 #include "defs.h"
 #include "exo_stream.h"
 
+/*
+ * Combined Beatty and DAG scheduler stream.
+ *
+ * The kernel first initializes the individual scheduler modules
+ * (dag_sched_init() and beatty_sched_init()) and then registers a
+ * single exo stream that chains them together.  Beatty dispatches
+ * according to its irrational weights and falls through to the DAG
+ * scheduler when nodes become ready.  Call beatty_dag_stream_init()
+ * early during boot before user tasks begin executing so that
+ * libraries can submit DAG nodes and configure Beatty weights via
+ * beatty_sched_set_tasks().
+ */
+
 static struct exo_stream beatty_dag_stream;
 
 void beatty_dag_stream_init(void) {


### PR DESCRIPTION
## Summary
- document how the Beatty scheduler integrates with the DAG engine
- clarify initialization order in `beatty_dag_stream.c`
- highlight `beatty_dag_demo` integrated behavior

## Testing
- `clang-format -i src-kernel/beatty_dag_stream.c`
- `make -j$(nproc)` *(fails: exo_cpu.h missing)*