### PR TITLE
Update setup instructions for pre-commit

### DIFF
--- a/README
+++ b/README
@@ -74,7 +74,10 @@ This only needs to be done after cloning the repository or when
 dependencies change.
 
 The repository uses ``pre-commit`` hooks to automatically run
-``clang-format`` and ``clang-tidy``.  Install the hooks with::
+``clang-format`` and ``clang-tidy``.  The ``setup.sh`` script attempts to
+install ``pre-commit`` via the distribution package manager and falls
+back to Python's ``pip`` if required.  Once installed, enable the hooks
+with::
 
     pre-commit install
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,10 +28,10 @@ apt_pin_install(){
     fi
   fi
 
-  # Fallback to pip for python packages
+  # Fallback to pip for Python packages
   if ! dpkg -s "$pkg" >/dev/null 2>&1; then
     case "$pkg" in
-      python3-*)
+      python3-*|pre-commit)
         pip_pkg="${pkg#python3-}"
         pip_install "$pip_pkg"
         ;;


### PR DESCRIPTION
## Summary
- fall back to `pip` when installing `pre-commit`
- document automatic `pre-commit` install in README

## Testing
- `make check`
- `apt-get install -y pre-commit` *(fails: Unable to locate package)*
- `pip3 install pre-commit` *(fails: Could not find a version)*