### PR TITLE
Add cpu_relax and integrate into spinlocks

### DIFF
--- a/src-headers/aarch64.h
+++ b/src-headers/aarch64.h
@@ -1,0 +1,3 @@
+#pragma once
+
+static inline void cpu_relax(void) { asm volatile("yield" ::: "memory"); }

--- a/src-headers/x86.h
+++ b/src-headers/x86.h
@@ -103,6 +103,8 @@ static inline void cli(void) { asm volatile("cli"); }
 
 static inline void sti(void) { asm volatile("sti"); }
 
+static inline void cpu_relax(void) { asm volatile("pause" ::: "memory"); }
+
 static inline uint xchg(volatile uint *addr, uint newval) {
   uint result;
 

--- a/src-kernel/spinlock.c
+++ b/src-kernel/spinlock.c
@@ -3,7 +3,11 @@
 #include "types.h"
 #include "defs.h"
 #include "param.h"
+#if defined(__aarch64__)
+#include "aarch64.h"
+#else
 #include "x86.h"
+#endif
 #include "memlayout.h"
 #include "mmu.h"
 #include "proc.h"
@@ -31,7 +35,7 @@ acquire(struct spinlock *lk)
 
   uint16_t ticket = __atomic_fetch_add(&lk->ticket.tail, 1, __ATOMIC_SEQ_CST);
   while(__atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST) != ticket)
-    ;
+    cpu_relax();
 
   // Tell the C compiler and the processor to not move loads or stores
   // past this point, to ensure that the critical section's memory


### PR DESCRIPTION
## Summary
- add cpu_relax for x86 using the `pause` instruction
- provide aarch64 implementation using `yield`
- invoke cpu_relax() when spinning on a ticket lock

## Testing
- `make` *(fails: kernel/exo_cpu.h: No such file or directory)*