### PR TITLE
Remove incomplete enqueue_ready function

### DIFF
--- a/src-kernel/dag_sched.c
+++ b/src-kernel/dag_sched.c
@@ -46,10 +46,6 @@ void dag_node_add_dep(struct dag_node *parent, struct dag_node *child) {
 }
 
 
-static void enqueue_ready(struct dag_node *n) {
-  struct dag_node **pp = &ready_head;
-  while (*pp && (*pp)->priority >= n->priority)
-
 static void
 enqueue_ready(struct dag_node *n)
 {


### PR DESCRIPTION
## Summary
- clean up duplicate definition in `dag_sched.c`

## Testing
- `make` *(fails: kernel/exo_cpu.h: No such file or directory)*