### PR TITLE
Add qspinlock implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ OBJS = \
     $(KERNEL_DIR)/proc.o \
     $(KERNEL_DIR)/sleeplock.o \
     $(KERNEL_DIR)/spinlock.o \
+    $(KERNEL_DIR)/qspinlock.o \
     $(KERNEL_DIR)/rcu.o \
     $(KERNEL_DIR)/string.o \
     $(KERNEL_DIR)/syscall.o \
@@ -421,6 +422,7 @@ _wc\
         _chan_beatty_rcrs_demo\
         _libos_posix_test\
         _libos_posix_extra_test\
+        _qspin_demo\
 
 
 ifeq ($(ARCH),x86_64)

--- a/doc/qspinlock.md
+++ b/doc/qspinlock.md
@@ -1,0 +1,32 @@
+#Quantum - inspired Spinlock(QSpinlock)
+
+The qspinlock API extends xv6's ticket-based spinlocks with a randomized
+back-off strategy. When a CPU fails to immediately acquire the lock, it
+waits for a pseudo-random delay before retrying. On x86 systems with the
+`RDRAND` instruction the delay is derived from hardware randomness;
+otherwise a simple linear congruential generator is
+        used.
+
+    This approach draws inspiration from quantum algorithms that introduce
+        probabilistic behavior to avoid contention.The
+            random delay reduces cache -
+    line bouncing between cores waiting on the same lock.
+
+    ##Interface
+
+``` void
+    qspin_lock(struct spinlock *lk);
+void qspin_unlock(struct spinlock *lk);
+int qspin_trylock(struct spinlock *lk); // returns 1 on success
+```
+
+`qspin_lock` behaves like `acquire` but adds randomized back-off while
+spinning. `qspin_trylock` attempts to acquire the lock without blocking.
+Existing `acquire`/`release` continue to work unaffected.
+
+## Usage
+
+QSpinlocks are useful when many cores contend for the same lock. They can
+reduce contention spikes in scheduler queues, I/O paths or other hot
+structures. Because they share the same `struct spinlock`, existing code
+can adopt qspinlocks without structural changes.

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -173,6 +173,9 @@ void initlock(struct spinlock *, char *);
 void release(struct spinlock *);
 void pushcli(void);
 void popcli(void);
+void qspin_lock(struct spinlock *);
+void qspin_unlock(struct spinlock *);
+int qspin_trylock(struct spinlock *);
 
 // sleeplock.c
 void acquiresleep(struct sleeplock *);

--- a/src-headers/qspinlock.h
+++ b/src-headers/qspinlock.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "spinlock.h"
+
+void qspin_lock(struct spinlock *lk);
+void qspin_unlock(struct spinlock *lk);
+int qspin_trylock(struct spinlock *lk);

--- a/src-kernel/qspinlock.c
+++ b/src-kernel/qspinlock.c
@@ -1,0 +1,69 @@
+#include "types.h"
+#include "defs.h"
+#include "param.h"
+#if defined(__aarch64__)
+#include "aarch64.h"
+#else
+#include "x86.h"
+#endif
+#include "spinlock.h"
+#include "qspinlock.h"
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <x86intrin.h>
+#endif
+
+static inline uint32_t rand32(void) {
+#if defined(__x86_64__) || defined(__i386__)
+  unsigned int r;
+  if (__builtin_ia32_rdrand32_step(&r))
+    return r;
+#endif
+  static uint32_t seed = 2463534242U;
+  seed = seed * 1103515245 + 12345;
+  return seed;
+}
+
+void qspin_lock(struct spinlock *lk) {
+  pushcli();
+  if (holding(lk))
+    panic("qspin_lock");
+
+  uint16_t ticket = __atomic_fetch_add(&lk->ticket.tail, 1, __ATOMIC_SEQ_CST);
+  while (__atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST) != ticket) {
+    uint32_t delay = rand32() & 0xff;
+    while (delay--)
+      cpu_relax();
+  }
+
+  __sync_synchronize();
+  lk->cpu = mycpu();
+  getcallerpcs(&lk, lk->pcs);
+}
+
+void qspin_unlock(struct spinlock *lk) {
+  if (!holding(lk))
+    panic("qspin_unlock");
+  lk->pcs[0] = 0;
+  lk->cpu = 0;
+  __sync_synchronize();
+  __atomic_fetch_add(&lk->ticket.head, 1, __ATOMIC_SEQ_CST);
+  popcli();
+}
+
+int qspin_trylock(struct spinlock *lk) {
+  pushcli();
+  if (holding(lk))
+    panic("qspin_trylock");
+  uint16_t head = __atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST);
+  uint16_t expected = head;
+  if (!__atomic_compare_exchange_n(&lk->ticket.tail, &expected, head + 1, false,
+                                   __ATOMIC_SEQ_CST, __ATOMIC_RELAXED)) {
+    popcli();
+    return 0;
+  }
+  __sync_synchronize();
+  lk->cpu = mycpu();
+  getcallerpcs(&lk, lk->pcs);
+  return 1;
+}

--- a/src-uland/qspin_demo.c
+++ b/src-uland/qspin_demo.c
@@ -1,0 +1,7 @@
+#include "types.h"
+#include "user.h"
+
+int main(int argc, char **argv) {
+  printf(1, "qspinlock demo running\n");
+  exit();
+}


### PR DESCRIPTION
## Summary
- add qspinlock API header
- implement qspin_lock, qspin_unlock and qspin_trylock using ticket lock with randomized back-off
- document qspinlock design
- compile qspinlock demo program
- hook qspinlock object into build

## Testing
- `clang-tidy src-kernel/qspinlock.c -- -I. -Isrc-headers -Isrc-kernel -Isrc-uland -Iproto` *(fails: unknown key 'Standard')*
- `make check`