### PR TITLE
Enable clang-tidy with local compile database generation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,4 +2,3 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
-Standard: c23

--- a/.clang-tidy-cpp17
+++ b/.clang-tidy-cpp17
@@ -2,4 +2,3 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
-Standard: c++17

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
       types: [c, h, cpp, cxx, hpp, hxx, cc, hh]
     - id: clang-tidy-c23
       name: clang-tidy (C23)
-      entry: clang-tidy --config-file=.clang-tidy
+      entry: scripts/run-clang-tidy.sh --config-file=.clang-tidy
       language: system
       pass_filenames: true
       types: [c, h]
     - id: clang-tidy-cpp17
       name: clang-tidy (C++17)
-      entry: clang-tidy --config-file=.clang-tidy-cpp17
+      entry: scripts/run-clang-tidy.sh --config-file=.clang-tidy-cpp17
       language: system
       pass_filenames: true
       types: [cpp, cxx, cc, c++, hpp, hxx, hh]

--- a/README
+++ b/README
@@ -83,6 +83,10 @@ with::
 
 The checks will run on every commit.
 
+``clang-tidy`` is wrapped by ``scripts/run-clang-tidy.sh`` which
+generates ``compile_commands.json`` on demand using
+``scripts/gen_compile_commands.py`` if it doesn't already exist.
+
 Experimental support for building with the C23 standard and for
 cross-compiling a 64-bit version is available. Set
 ``ARCH=x86_64`` when invoking make to enable 64-bit builds and adjust

--- a/scripts/gen_compile_commands.py
+++ b/scripts/gen_compile_commands.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import subprocess, json, shlex, os, re, sys
+
+def main():
+    make_args = ["make", "-n"] + sys.argv[1:]
+    try:
+        output = subprocess.check_output(make_args, text=True)
+    except subprocess.CalledProcessError as e:
+        output = e.output
+    commands = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if not re.match(r'^(?:gcc|cc|clang) ', line):
+            continue
+        tokens = shlex.split(line)
+        src = None
+        for tok in tokens:
+            if tok.endswith('.c'):
+                src = tok
+        if not src:
+            continue
+        cmd = line
+        commands.append({"directory": os.getcwd(), "command": cmd, "file": src})
+    if commands:
+        with open('compile_commands.json', 'w') as f:
+            json.dump(commands, f, indent=2)
+    else:
+        sys.stderr.write('No compile commands captured\n')
+        return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+# Generate compile_commands.json if missing
+if [ ! -f compile_commands.json ]; then
+  if command -v python3 >/dev/null 2>&1 && [ -f scripts/gen_compile_commands.py ]; then
+    python3 scripts/gen_compile_commands.py >/dev/null
+  fi
+fi
+exec clang-tidy -p . "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -255,6 +255,11 @@ if command -v compiledb >/dev/null 2>&1; then
     echo "Warning: failed to generate compile_commands.json (exit code $status)" >&2
     echo "compiledb" >>"$FAIL_LOG"
   fi
+elif [ -x scripts/gen_compile_commands.py ]; then
+  if ! python3 scripts/gen_compile_commands.py >/dev/null 2>&1; then
+    echo "Warning: gen_compile_commands.py failed" >&2
+    echo "gen_compile_commands" >>"$FAIL_LOG"
+  fi
 fi
 
 # Install pre-commit hooks if possible


### PR DESCRIPTION
## Summary
- provide a small script to generate `compile_commands.json`
- wrap clang-tidy in a helper that auto-generates the database
- hook the wrapper into pre-commit
- fall back to the generator from `setup.sh`
- document how clang-tidy is invoked

## Testing
- `python3 scripts/gen_compile_commands.py`
- `scripts/run-clang-tidy.sh src-kernel/proc.c`