### PR TITLE
Implement microdelay and add exokernel headers

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -198,8 +198,6 @@ int fetchint(uint, int *);
 int fetchstr(uint, char **);
 void syscall(void);
 
-syscall(void);
-
 // timer.c
 void timerinit(void);
 

--- a/src-kernel/kernel/exo_cpu.h
+++ b/src-kernel/kernel/exo_cpu.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+#include "proc.h"
+
+#if defined(__x86_64__) || defined(__aarch64__)
+typedef struct context64 context_t;
+#else
+typedef struct context context_t;
+#endif
+
+void swtch(context_t **old, context_t *new);
+int exo_yield_to(exo_cap target);

--- a/src-kernel/kernel/exo_disk.h
+++ b/src-kernel/kernel/exo_disk.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+
+int exo_read_disk(struct exo_blockcap cap, void *dst, uint64 off, uint64 n);
+int exo_write_disk(struct exo_blockcap cap, const void *src, uint64 off,
+                   uint64 n);

--- a/src-kernel/kernel/exo_ipc.h
+++ b/src-kernel/kernel/exo_ipc.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+
+struct exo_ipc_ops {
+  int (*send)(exo_cap dest, const void *buf, uint64 len);
+  int (*recv)(exo_cap src, void *buf, uint64 len);
+};
+
+void exo_ipc_register(struct exo_ipc_ops *ops);
+int exo_send(exo_cap dest, const void *buf, uint64 len);
+int exo_recv(exo_cap src, void *buf, uint64 len);
+
+int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64 len);
+int exo_ipc_queue_recv(exo_cap src, void *buf, uint64 len);
+extern struct exo_ipc_ops exo_ipc_queue_ops;

--- a/src-kernel/kernel/exo_mem.h
+++ b/src-kernel/kernel/exo_mem.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+/* Placeholder for future memory capability interfaces */

--- a/src-kernel/lapic.c
+++ b/src-kernel/lapic.c
@@ -11,50 +11,46 @@
 #include "x86.h"
 
 // Local APIC registers, divided by 4 for use as uint[] indices.
-#define ID      (0x0020/4)   // ID
-#define VER     (0x0030/4)   // Version
-#define TPR     (0x0080/4)   // Task Priority
-#define EOI     (0x00B0/4)   // EOI
-#define SVR     (0x00F0/4)   // Spurious Interrupt Vector
-  #define ENABLE     0x00000100   // Unit Enable
-#define ESR     (0x0280/4)   // Error Status
-#define ICRLO   (0x0300/4)   // Interrupt Command
-  #define INIT       0x00000500   // INIT/RESET
-  #define STARTUP    0x00000600   // Startup IPI
-  #define DELIVS     0x00001000   // Delivery status
-  #define ASSERT     0x00004000   // Assert interrupt (vs deassert)
-  #define DEASSERT   0x00000000
-  #define LEVEL      0x00008000   // Level triggered
-  #define BCAST      0x00080000   // Send to all APICs, including self.
-  #define BUSY       0x00001000
-  #define FIXED      0x00000000
-#define ICRHI   (0x0310/4)   // Interrupt Command [63:32]
-#define TIMER   (0x0320/4)   // Local Vector Table 0 (TIMER)
-  #define X1         0x0000000B   // divide counts by 1
-  #define PERIODIC   0x00020000   // Periodic
-#define PCINT   (0x0340/4)   // Performance Counter LVT
-#define LINT0   (0x0350/4)   // Local Vector Table 1 (LINT0)
-#define LINT1   (0x0360/4)   // Local Vector Table 2 (LINT1)
-#define ERROR   (0x0370/4)   // Local Vector Table 3 (ERROR)
-  #define MASKED     0x00010000   // Interrupt masked
-#define TICR    (0x0380/4)   // Timer Initial Count
-#define TCCR    (0x0390/4)   // Timer Current Count
-#define TDCR    (0x03E0/4)   // Timer Divide Configuration
+#define ID (0x0020 / 4)    // ID
+#define VER (0x0030 / 4)   // Version
+#define TPR (0x0080 / 4)   // Task Priority
+#define EOI (0x00B0 / 4)   // EOI
+#define SVR (0x00F0 / 4)   // Spurious Interrupt Vector
+#define ENABLE 0x00000100  // Unit Enable
+#define ESR (0x0280 / 4)   // Error Status
+#define ICRLO (0x0300 / 4) // Interrupt Command
+#define INIT 0x00000500    // INIT/RESET
+#define STARTUP 0x00000600 // Startup IPI
+#define DELIVS 0x00001000  // Delivery status
+#define ASSERT 0x00004000  // Assert interrupt (vs deassert)
+#define DEASSERT 0x00000000
+#define LEVEL 0x00008000 // Level triggered
+#define BCAST 0x00080000 // Send to all APICs, including self.
+#define BUSY 0x00001000
+#define FIXED 0x00000000
+#define ICRHI (0x0310 / 4)  // Interrupt Command [63:32]
+#define TIMER (0x0320 / 4)  // Local Vector Table 0 (TIMER)
+#define X1 0x0000000B       // divide counts by 1
+#define PERIODIC 0x00020000 // Periodic
+#define PCINT (0x0340 / 4)  // Performance Counter LVT
+#define LINT0 (0x0350 / 4)  // Local Vector Table 1 (LINT0)
+#define LINT1 (0x0360 / 4)  // Local Vector Table 2 (LINT1)
+#define ERROR (0x0370 / 4)  // Local Vector Table 3 (ERROR)
+#define MASKED 0x00010000   // Interrupt masked
+#define TICR (0x0380 / 4)   // Timer Initial Count
+#define TCCR (0x0390 / 4)   // Timer Current Count
+#define TDCR (0x03E0 / 4)   // Timer Divide Configuration
 
-volatile uint *lapic;  // Initialized in mp.c
+volatile uint *lapic; // Initialized in mp.c
 
-//PAGEBREAK!
-static void
-lapicw(int index, int value)
-{
+// PAGEBREAK!
+static void lapicw(int index, int value) {
   lapic[index] = value;
-  lapic[ID];  // wait for write to finish, by reading
+  lapic[ID]; // wait for write to finish, by reading
 }
 
-void
-lapicinit(void)
-{
-  if(!lapic)
+void lapicinit(void) {
+  if (!lapic)
     return;
 
   // Enable local APIC; set spurious interrupt vector.
@@ -74,7 +70,7 @@ lapicinit(void)
 
   // Disable performance counter overflow interrupts
   // on machines that provide that interrupt entry.
-  if(((lapic[VER]>>16) & 0xFF) >= 4)
+  if (((lapic[VER] >> 16) & 0xFF) >= 4)
     lapicw(PCINT, MASKED);
 
   // Map error interrupt to IRQ_ERROR.
@@ -90,111 +86,117 @@ lapicinit(void)
   // Send an Init Level De-Assert to synchronise arbitration ID's.
   lapicw(ICRHI, 0);
   lapicw(ICRLO, BCAST | INIT | LEVEL);
-  while(lapic[ICRLO] & DELIVS)
+  while (lapic[ICRLO] & DELIVS)
     ;
 
   // Enable interrupts on the APIC (but not on the processor).
   lapicw(TPR, 0);
 }
 
-int
-lapicid(void)
-{
+int lapicid(void) {
   if (!lapic)
     return 0;
   return lapic[ID] >> 24;
 }
 
 // Acknowledge interrupt.
-void
-lapiceoi(void)
-{
-  if(lapic)
+void lapiceoi(void) {
+  if (lapic)
     lapicw(EOI, 0);
 }
 
 // Spin for a given number of microseconds.
-// On real hardware would want to tune this dynamically.
-void
-microdelay(int us)
-{
+// This implementation uses the timestamp counter on x86 as a crude
+// busy wait.  The value of cycles_per_us is only an approximation and
+// is sufficient for the short delays used during early hardware
+// initialisation.
+static inline uint64 read_tsc(void) {
+  uint lo, hi;
+  asm volatile("rdtsc" : "=a"(lo), "=d"(hi));
+  return ((uint64)hi << 32) | lo;
 }
 
-#define CMOS_PORT    0x70
-#define CMOS_RETURN  0x71
+static const uint64 cycles_per_us = 3000; // ~3 GHz
+
+void microdelay(int us) {
+#if defined(__i386__) || defined(__x86_64__)
+  uint64 end = read_tsc() + (uint64)us * cycles_per_us;
+  while (read_tsc() < end)
+    cpu_relax();
+#else
+  // Fallback: simple loop on non-x86 architectures.
+  for (volatile int i = 0; i < us * 100; i++)
+    ;
+#endif
+}
+
+#define CMOS_PORT 0x70
+#define CMOS_RETURN 0x71
 
 // Start additional processor running entry code at addr.
 // See Appendix B of MultiProcessor Specification.
-void
-lapicstartap(uchar apicid, uint addr)
-{
+void lapicstartap(uchar apicid, uint addr) {
   int i;
   ushort *wrv;
 
   // "The BSP must initialize CMOS shutdown code to 0AH
   // and the warm reset vector (DWORD based at 40:67) to point at
   // the AP startup code prior to the [universal startup algorithm]."
-  outb(CMOS_PORT, 0xF);  // offset 0xF is shutdown code
-  outb(CMOS_PORT+1, 0x0A);
-  wrv = (ushort*)P2V((0x40<<4 | 0x67));  // Warm reset vector
+  outb(CMOS_PORT, 0xF); // offset 0xF is shutdown code
+  outb(CMOS_PORT + 1, 0x0A);
+  wrv = (ushort *)P2V((0x40 << 4 | 0x67)); // Warm reset vector
   wrv[0] = 0;
   wrv[1] = addr >> 4;
 
   // "Universal startup algorithm."
   // Send INIT (level-triggered) interrupt to reset other CPU.
-  lapicw(ICRHI, apicid<<24);
+  lapicw(ICRHI, apicid << 24);
   lapicw(ICRLO, INIT | LEVEL | ASSERT);
   microdelay(200);
   lapicw(ICRLO, INIT | LEVEL);
-  microdelay(100);    // should be 10ms, but too slow in Bochs!
+  microdelay(100); // should be 10ms, but too slow in Bochs!
 
   // Send startup IPI (twice!) to enter code.
   // Regular hardware is supposed to only accept a STARTUP
   // when it is in the halted state due to an INIT.  So the second
   // should be ignored, but it is part of the official Intel algorithm.
   // Bochs complains about the second one.  Too bad for Bochs.
-  for(i = 0; i < 2; i++){
-    lapicw(ICRHI, apicid<<24);
-    lapicw(ICRLO, STARTUP | (addr>>12));
+  for (i = 0; i < 2; i++) {
+    lapicw(ICRHI, apicid << 24);
+    lapicw(ICRLO, STARTUP | (addr >> 12));
     microdelay(200);
   }
 }
 
-#define CMOS_STATA   0x0a
-#define CMOS_STATB   0x0b
-#define CMOS_UIP    (1 << 7)        // RTC update in progress
+#define CMOS_STATA 0x0a
+#define CMOS_STATB 0x0b
+#define CMOS_UIP (1 << 7) // RTC update in progress
 
-#define SECS    0x00
-#define MINS    0x02
-#define HOURS   0x04
-#define DAY     0x07
-#define MONTH   0x08
-#define YEAR    0x09
+#define SECS 0x00
+#define MINS 0x02
+#define HOURS 0x04
+#define DAY 0x07
+#define MONTH 0x08
+#define YEAR 0x09
 
-static uint
-cmos_read(uint reg)
-{
-  outb(CMOS_PORT,  reg);
+static uint cmos_read(uint reg) {
+  outb(CMOS_PORT, reg);
   microdelay(200);
 
   return inb(CMOS_RETURN);
 }
 
-static void
-fill_rtcdate(struct rtcdate *r)
-{
+static void fill_rtcdate(struct rtcdate *r) {
   r->second = cmos_read(SECS);
   r->minute = cmos_read(MINS);
-  r->hour   = cmos_read(HOURS);
-  r->day    = cmos_read(DAY);
-  r->month  = cmos_read(MONTH);
-  r->year   = cmos_read(YEAR);
+  r->hour = cmos_read(HOURS);
+  r->day = cmos_read(DAY);
+  r->month = cmos_read(MONTH);
+  r->year = cmos_read(YEAR);
 }
 
 // qemu seems to use 24-hour GWT and the values are BCD encoded
-void
-cmostime(struct rtcdate *r)
-{
+void cmostime(struct rtcdate *r) {
   struct rtcdate t1, t2;
   int sb, bcd;
 
@@ -203,25 +205,25 @@ cmostime(struct rtcdate *r)
   bcd = (sb & (1 << 2)) == 0;
 
   // make sure CMOS doesn't modify time while we read it
-  for(;;) {
+  for (;;) {
     fill_rtcdate(&t1);
-    if(cmos_read(CMOS_STATA) & CMOS_UIP)
-        continue;
+    if (cmos_read(CMOS_STATA) & CMOS_UIP)
+      continue;
     fill_rtcdate(&t2);
-    if(memcmp(&t1, &t2, sizeof(t1)) == 0)
+    if (memcmp(&t1, &t2, sizeof(t1)) == 0)
       break;
   }
 
   // convert
-  if(bcd) {
-#define    CONV(x)     (t1.x = ((t1.x >> 4) * 10) + (t1.x & 0xf))
+  if (bcd) {
+#define CONV(x) (t1.x = ((t1.x >> 4) * 10) + (t1.x & 0xf))
     CONV(second);
     CONV(minute);
-    CONV(hour  );
-    CONV(day   );
-    CONV(month );
-    CONV(year  );
-#undef     CONV
+    CONV(hour);
+    CONV(day);
+    CONV(month);
+    CONV(year);
+#undef CONV
   }
 
   *r = t1;


### PR DESCRIPTION
## Summary
- implement `microdelay` using the timestamp counter
- add missing kernel headers for exokernel support
- clean up duplicate declaration in `defs.h`

## Testing
- `clang-format -i src-kernel/lapic.c src-headers/defs.h src-kernel/kernel/exo_cpu.h src-kernel/kernel/exo_disk.h src-kernel/kernel/exo_ipc.h src-kernel/kernel/exo_mem.h`
- `make ARCH=i386` *(fails: undeclared identifiers and other build issues)*