### PR TITLE
Add recursive spinlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ OBJS = \
     $(KERNEL_DIR)/sleeplock.o \
     $(KERNEL_DIR)/spinlock.o \
     $(KERNEL_DIR)/qspinlock.o \
+    $(KERNEL_DIR)/rspinlock.o \
     $(KERNEL_DIR)/rcu.o \
     $(KERNEL_DIR)/string.o \
     $(KERNEL_DIR)/syscall.o \

--- a/src-headers/rspinlock.h
+++ b/src-headers/rspinlock.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "spinlock.h"
+
+struct rspinlock {
+  struct spinlock lk;  // underlying spinlock
+  struct cpu *owner;   // current owner CPU
+  int depth;           // recursion depth
+};
+
+void rinitlock(struct rspinlock *rlk, char *name);
+void racquire(struct rspinlock *rlk);
+void rrelease(struct rspinlock *rlk);
+int rholding(struct rspinlock *rlk);
+
+#define WITH_RSPINLOCK(rlk) \
+  for(int _once = (racquire(rlk), 0); !_once; rrelease(rlk), _once = 1)

--- a/src-kernel/rspinlock.c
+++ b/src-kernel/rspinlock.c
@@ -1,0 +1,46 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "rspinlock.h"
+
+void
+rinitlock(struct rspinlock *rlk, char *name)
+{
+  initlock(&rlk->lk, name);
+  rlk->owner = 0;
+  rlk->depth = 0;
+}
+
+void
+racquire(struct rspinlock *rlk)
+{
+  pushcli();
+  if(rlk->owner == mycpu()){
+    rlk->depth++;
+    return;
+  }
+  acquire(&rlk->lk);
+  rlk->owner = mycpu();
+  rlk->depth = 1;
+}
+
+void
+rrelease(struct rspinlock *rlk)
+{
+  if(rlk->owner != mycpu() || rlk->depth == 0)
+    panic("rrelease");
+  if(--rlk->depth == 0){
+    rlk->owner = 0;
+    release(&rlk->lk);
+  }
+  popcli();
+}
+
+int
+rholding(struct rspinlock *rlk)
+{
+  pushcli();
+  int r = rlk->owner == mycpu();
+  popcli();
+  return r;
+}


### PR DESCRIPTION
## Summary
- implement recursive spinlock type
- expose convenience macro for scoped usage
- build new rspinlock object

## Testing
- `make src-kernel/rspinlock.o`
- `make` *(fails: lapic.c errors unrelated to this change)*