### PR TITLE
Fix duplicate trapframe declaration in defs.h

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -27,7 +27,6 @@ struct spinlock;
 struct sleeplock;
 struct stat;
 struct superblock;
-struct trapframe;
 struct exo_cap;
 struct exo_blockcap;
 struct exo_sched_ops;


### PR DESCRIPTION
## Summary
- remove duplicate `struct trapframe` forward declaration

## Testing
- `make ARCH=x86` *(fails: undefined reference to `beatty_dag_stream_init`)*