### PR TITLE
Switch dag scheduler to qspin lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ OBJS = \
     $(KERNEL_DIR)/fastipc.o \
     $(KERNEL_DIR)/endpoint.o \
     $(KERNEL_DIR)/dag_sched.o \
-    $(KERNEL_DIR)/beatty_sched.o
+    $(KERNEL_DIR)/beatty_sched.o \
+    $(KERNEL_DIR)/beatty_dag_stream.o
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o

--- a/src-headers/user.h
+++ b/src-headers/user.h
@@ -39,7 +39,7 @@ int exo_unbind_page(exo_cap *cap);
 int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap);
 int exo_bind_block(exo_blockcap *cap, void *data, int write);
 int exo_flush_block(exo_blockcap *cap, void *data);
-int exo_yield_to(exo_cap *target);
+int exo_yield_to(exo_cap target);
 int set_gas(uint64 amount);
 int get_gas(void);
 int exo_send(exo_cap *dest, const void *buf, uint64 len);


### PR DESCRIPTION
## Summary
- add Beatty DAG stream object to build
- use qspinlock for `dag_lock`
- fix user header `exo_yield_to` prototype

## Testing
- `make ARCH=i386 kernel`
- `make check`
