### PR TITLE
Add simple pytest harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       run: swift/build_swift.sh
     - name: Build
       run: make ARCH=${{ matrix.arch }} QEMU=echo qemu-nox
+    - name: Run unit tests
+      run: make check
     - name: Run fuzz smoke test
       run: python3 scripts/swift_fuzz.py -runs=1
     - name: Clean

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ kernelmemfs
 mkfs
 .gdbinit
 fuzz
+src-uland/exo_unit_test

--- a/Makefile
+++ b/Makefile
@@ -572,6 +572,7 @@ src-uland/exo_unit_test: src-uland/exo_unit_test.c
 
 check: src-uland/exo_unit_test
 	./src-uland/exo_unit_test
+	pytest -q
 
 clang-tidy:
 	@for f in $(TIDY_SRCS); do \

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,15 @@
+"""Simulation harness for xv6 testing.
+This is a placeholder script providing a minimal interface
+for automated tests.  It currently does nothing beyond
+indicating successful completion.
+"""
+
+def main() -> int:
+    """Run the simulation harness and return 0 on success."""
+    # In a real environment this function would invoke the
+    # xv6 simulator (e.g. QEMU) and run a suite of checks.
+    # Here we simply return success to keep the CI test fast.
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,0 +1,11 @@
+import pathlib
+import sys
+
+# Ensure repository root is in sys.path
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import simulate
+
+def test_simulate_harness_completes():
+    assert simulate.main() == 0


### PR DESCRIPTION
## Summary
- create a minimal `simulate.py` harness
- add a pytest test that imports and runs the harness
- call `pytest` from `make check`
- run `make check` in CI
- ignore generated `src-uland/exo_unit_test` binary

## Testing
- `make check`