### PR TITLE
Add STREAMS simulation utilities

### DIFF
--- a/README
+++ b/README
@@ -355,3 +355,18 @@ $ python3 scripts/swift_fuzz.py -runs=1
 ```
 
 Additional libFuzzer flags may be provided after the script name.
+
+STREAMS STACK
+-------------
+A simple simulation of STREAMS modules is provided. The `streams_stack.dot`
+file describes the module layout. Generate an image with Graphviz:
+
+```
+$ dot -Tpng streams_stack.dot -o stack.png
+```
+
+Run the latency harness with Python:
+
+```
+$ python3 scripts/simulate.py
+```

--- a/encrypt_mod.py
+++ b/encrypt_mod.py
@@ -1,0 +1,11 @@
+from stream_module import mblk_t
+
+class XorEncryptModule:
+    """Simple XOR encryption/decryption module."""
+
+    def __init__(self, key: int):
+        self.key = key & 0xFF
+
+    def __call__(self, mblk: mblk_t) -> mblk_t:
+        mblk.data = bytearray(b ^ self.key for b in mblk.data)
+        return mblk

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Latency test harness for STREAMS module stack."""
+
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from encrypt_mod import XorEncryptModule
+from stream_module import mblk_t, attach_module
+
+
+def main() -> None:
+    key = 0x55
+    pipeline = attach_module([XorEncryptModule(key)])
+    iterations = 10000
+    start = time.perf_counter()
+    for _ in range(iterations):
+        msg = mblk_t(b"hello")
+        pipeline(msg)
+    elapsed = time.perf_counter() - start
+    print(f"Average latency: {elapsed / iterations * 1e6:.2f} us")
+
+
+if __name__ == "__main__":
+    main()

--- a/stream_module.py
+++ b/stream_module.py
@@ -1,0 +1,31 @@
+class mblk_t:
+    """Simple message block holding byte data."""
+
+    def __init__(self, data: bytes):
+        self.data = bytearray(data)
+
+
+class queue_t:
+    """FIFO queue of message blocks."""
+
+    def __init__(self):
+        self._msgs = []
+
+    def put(self, mblk: mblk_t) -> None:
+        self._msgs.append(mblk)
+
+    def get(self) -> mblk_t | None:
+        if not self._msgs:
+            return None
+        return self._msgs.pop(0)
+
+
+def attach_module(modules):
+    """Chain module callables into a processing pipeline."""
+
+    def _run(mblk: mblk_t) -> mblk_t:
+        for mod in modules:
+            mblk = mod(mblk)
+        return mblk
+
+    return _run

--- a/streams_stack.dot
+++ b/streams_stack.dot
@@ -1,0 +1,5 @@
+digraph StreamsStack {
+    rankdir=LR;
+    node [shape=box];
+    Application -> Encrypt -> Device;
+}


### PR DESCRIPTION
## Summary
- add `streams_stack.dot` with sample STREAMS stack diagram
- provide simple STREAMS message queue and XOR module
- implement latency test harness under `scripts/`
- document how to generate the stack graphic and run the harness

## Testing
- `python3 -m py_compile stream_module.py encrypt_mod.py scripts/simulate.py`
- `python3 scripts/simulate.py`