### PR TITLE
Fix PAGEBREAK handling and document shell PATH

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,8 +1,4 @@
-formatting:
-	need to fix PAGEBREAK mechanism
-
 sh:
        built-ins (e.g. cd) now run correctly within lists, pipes, and
        background commands.
-       maybe should hard-code PATH=/ ?
 

--- a/README
+++ b/README
@@ -10,7 +10,10 @@ but is implemented for a modern x86-based multiprocessor using ANSI C.
 
 The user-level shell supports built-in commands such as ``cd``.  These
 built-ins execute directly in the shell process even when used in command
-lists, pipelines, or background jobs.
+lists, pipelines, or background jobs. Programs invoked by the shell are
+searched for only in the root directory; if a command does not include a
+slash, the shell automatically prefixes ``/`` before executing it. xv6
+does not implement a ``PATH`` environment variable.
 
 ACKNOWLEDGMENTS
 

--- a/runoff1
+++ b/runoff1
@@ -33,9 +33,9 @@ for($i=0; $i<@lines; ){
 	last if $i>=@lines;
 
 	# If the rest of the file fits, use the whole thing.
-	if(@lines <= $i+50 && !grep { /PAGEBREAK/ } @lines){
-		$breakbefore = @lines;
-	}else{
+        if(@lines - $i <= 50 && !grep { /PAGEBREAK/ } @lines[$i .. $#lines]){
+                $breakbefore = @lines;
+        }else{
 		# Find a good next page break;
 		# Hope for end of function.
 		# but settle for a blank line (but not first blank line


### PR DESCRIPTION
## Summary
- correct PAGEBREAK detection in runoff1
- document that the shell always searches `/` for commands
- trim resolved notes from BUGS

## Testing
- `pytest -q`