### PR TITLE
Implement spinlock variants and add tests

### DIFF
--- a/src-kernel/qspinlock.c
+++ b/src-kernel/qspinlock.c
@@ -1,0 +1,75 @@
+#include "qspinlock.h"
+#include <stdint.h>
+
+struct cpu;
+
+extern struct cpu* mycpu(void);
+extern void getcallerpcs(void*, unsigned int*);
+extern void pushcli(void);
+extern void popcli(void);
+extern int holding(struct spinlock*);
+extern void panic(char*);
+
+static uint32_t lcg_rand(void)
+{
+  static uint32_t seed = 123456789;
+  seed = seed * 1103515245 + 12345;
+  return seed;
+}
+
+void
+qspin_lock(struct spinlock *lk)
+{
+  pushcli();
+  if(holding(lk))
+    panic("qspin_lock");
+
+  uint16_t ticket = __atomic_fetch_add(&lk->ticket.tail, 1, __ATOMIC_SEQ_CST);
+  while(__atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST) != ticket){
+    unsigned delay = (lcg_rand() & 0xff) + 1;
+    while(delay--)
+      __asm__ volatile("pause");
+  }
+
+  __sync_synchronize();
+  lk->cpu = mycpu();
+  getcallerpcs(&lk, lk->pcs);
+}
+
+void
+qspin_unlock(struct spinlock *lk)
+{
+  if(!holding(lk))
+    panic("qspin_unlock");
+  lk->pcs[0] = 0;
+  lk->cpu = 0;
+  __sync_synchronize();
+  __atomic_fetch_add(&lk->ticket.head, 1, __ATOMIC_SEQ_CST);
+  popcli();
+}
+
+int
+qspin_trylock(struct spinlock *lk)
+{
+  pushcli();
+  if(holding(lk))
+    panic("qspin_trylock");
+
+  uint16_t head = __atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST);
+  uint16_t tail = __atomic_load_n(&lk->ticket.tail, __ATOMIC_SEQ_CST);
+  if(head != tail){
+    popcli();
+    return 0;
+  }
+  uint16_t expected = tail;
+  if(!__atomic_compare_exchange_n(&lk->ticket.tail, &expected, tail+1, 0,
+                                  __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)){
+    popcli();
+    return 0;
+  }
+
+  __sync_synchronize();
+  lk->cpu = mycpu();
+  getcallerpcs(&lk, lk->pcs);
+  return 1;
+}

--- a/src-kernel/rspinlock.c
+++ b/src-kernel/rspinlock.c
@@ -1,0 +1,55 @@
+#include "rspinlock.h"
+
+struct cpu;
+
+extern struct cpu* mycpu(void);
+extern void pushcli(void);
+extern void popcli(void);
+extern void acquire(struct spinlock*);
+extern void release(struct spinlock*);
+extern int holding(struct spinlock*);
+extern void panic(char*);
+
+void
+rinitlock(struct rspinlock *rlk, char *name)
+{
+  rlk->owner = 0;
+  rlk->depth = 0;
+  initlock(&rlk->lk, name);
+}
+
+void
+racquire(struct rspinlock *rlk)
+{
+  pushcli();
+  if(rlk->owner == mycpu()){
+    rlk->depth++;
+    return;
+  }
+  acquire(&rlk->lk);
+  rlk->owner = mycpu();
+  rlk->depth = 1;
+}
+
+void
+rrelease(struct rspinlock *rlk)
+{
+  if(rlk->owner != mycpu() || rlk->depth < 1)
+    panic("rrelease");
+  rlk->depth--;
+  if(rlk->depth == 0){
+    rlk->owner = 0;
+    release(&rlk->lk);
+  }
+  popcli();
+}
+
+int
+rholding(struct rspinlock *rlk)
+{
+  int r;
+  pushcli();
+  r = (rlk->owner == mycpu());
+  popcli();
+  return r;
+}

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,67 @@
+import subprocess
+import tempfile
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = r"""
+#include <assert.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+
+typedef unsigned int uint;
+
+#include "src-headers/qspinlock.h"
+#include "src-headers/rspinlock.h"
+
+struct cpu { int ncli; int intena; };
+static struct cpu cpu0;
+
+static struct cpu* mycpu(void){ return &cpu0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; exit(1); }
+
+static void pushcli(void){ cpu0.ncli++; }
+static void popcli(void){ cpu0.ncli--; }
+static int holding(struct spinlock *lk){ return lk->cpu == &cpu0; }
+static void initlock(struct spinlock *lk, char *name){ lk->name=name; lk->ticket.head=0; lk->ticket.tail=0; lk->cpu=0; }
+static void acquire(struct spinlock *lk){ pushcli(); if(holding(lk)) panic("acq"); uint16_t t=atomic_fetch_add(&lk->ticket.tail,1); while(atomic_load(&lk->ticket.head)!=t) ; __sync_synchronize(); lk->cpu=&cpu0; }
+static void release(struct spinlock *lk){ if(!holding(lk)) panic("rel"); __sync_synchronize(); lk->cpu=0; atomic_fetch_add(&lk->ticket.head,1); popcli(); }
+
+#include "src-kernel/qspinlock.c"
+#include "src-kernel/rspinlock.c"
+
+int main(){
+    struct spinlock sl; initlock(&sl, "a");
+    assert(qspin_trylock(&sl));
+    qspin_unlock(&sl);
+    qspin_lock(&sl);
+    qspin_unlock(&sl);
+
+    struct rspinlock rl; rinitlock(&rl, "r");
+    racquire(&rl); racquire(&rl);
+    assert(rl.depth==2);
+    rrelease(&rl); assert(rl.depth==1);
+    rrelease(&rl); assert(rl.depth==0);
+    return 0;
+}
+"""
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        src.write_text(C_CODE)
+        exe = pathlib.Path(td)/"test"
+        subprocess.check_call([
+            "gcc","-std=c11",
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        subprocess.check_call([str(exe)])
+
+
+def test_lock_behaviour():
+    compile_and_run()


### PR DESCRIPTION
## Summary
- implement `qspin_lock`, `qspin_unlock`, `qspin_trylock`
- implement recursive spinlock helpers
- add a small unit test exercising the new locks

## Testing
- `pytest -q`