### PR TITLE
Fix documentation pagebreak & clarify shell PATH

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,8 +1,3 @@
-formatting:
-	need to fix PAGEBREAK mechanism
-
 sh:
-       built-ins (e.g. cd) now run correctly within lists, pipes, and
-       background commands.
-       maybe should hard-code PATH=/ ?
-
+        built-ins (e.g. cd) now run correctly within lists, pipes, and
+        background commands.

--- a/README
+++ b/README
@@ -12,6 +12,12 @@ The user-level shell supports built-in commands such as ``cd``.  These
 built-ins execute directly in the shell process even when used in command
 lists, pipelines, or background jobs.
 
+Programs are expected to reside directly under `/`.  If a command
+name does not include a slash, the shell automatically prepends `/`
+when searching for the executable.  xv6 does not support environment
+variables like `PATH`, so the shell's search path is effectively hard
+coded to just `/`.
+
 ACKNOWLEDGMENTS
 
 xv6 is inspired by John Lions's Commentary on UNIX 6th Edition (Peer

--- a/runoff1
+++ b/runoff1
@@ -33,9 +33,9 @@ for($i=0; $i<@lines; ){
 	last if $i>=@lines;
 
 	# If the rest of the file fits, use the whole thing.
-	if(@lines <= $i+50 && !grep { /PAGEBREAK/ } @lines){
-		$breakbefore = @lines;
-	}else{
+       if(@lines <= $i+50 && !grep { /PAGEBREAK/ } @lines[$i..$#lines]){
+               $breakbefore = @lines;
+       }else{
 		# Find a good next page break;
 		# Hope for end of function.
 		# but settle for a blank line (but not first blank line


### PR DESCRIPTION
## Summary
- fix PAGEBREAK detection in `runoff1`
- document shell search path in README
- clean up resolved BUGS entries

## Testing
- `./runoff1 -n 0 src-kernel/console.c >/tmp/out && head -n 5 /tmp/out`
- `make` *(fails: types.h: No such file or directory)*