### PR TITLE
Fix DAG scheduler memory leak

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -1,21 +1,18 @@
 
 """Simulation harness for xv6 testing.
 
-The original placeholder merely returned success.  The harness now
+The original placeholder merely returned success. The harness now
 invokes QEMU to boot the xv6 kernel and issues a trivial command
-sequence to ensure the guest is operational.  The exit status from
+sequence to ensure the guest is operational. The exit status from
 QEMU is propagated so CI runs can detect boot failures.
 
-"""Simple simulation harness for xv6.
-
-The :func:`main` entry point boots xv6 under QEMU, runs a short
-command sequence and returns QEMU's exit status.  It is intentionally
-minimal and is primarily used by the automated test suite.  The QEMU
-binary and image paths can be overridden through environment
-variables.  When running under the tests the ``QEMU`` variable is set
+This module's :func:`main` entry point boots xv6 under QEMU, runs a
+short command sequence and returns the emulator's exit status. It is
+intentionally minimal and primarily used by the automated test suite.
+The QEMU binary and image paths can be overridden through environment
+variables. When running under the tests the ``QEMU`` variable is set
 to ``/bin/true`` so the harness completes instantly without launching
 an emulator.
-
 """
 
 from __future__ import annotations

--- a/src-kernel/dag_sched.c
+++ b/src-kernel/dag_sched.c
@@ -66,27 +66,18 @@ dequeue_ready(void)
 }
 
 static void
-dag_free_children(struct dag_node *n)
-{
-  struct dag_node_list *l = n->children;
-  while(l){
-    struct dag_node_list *next = l->next;
-    kfree((char *)l);
-    l = next;
-  }
-  n->children = 0;
-}
-
-static void
 dag_mark_done(struct dag_node *n)
 {
-  struct dag_node_list *l;
-  for(l = n->children; l; l = l->next){
+  struct dag_node_list *l = n->children;
+  n->children = 0;
+  while(l){
+    struct dag_node_list *next = l->next;
     struct dag_node *child = l->node;
     if(--child->pending == 0)
       enqueue_ready(child);
+    kfree((char *)l); /* free allocation from dag_node_add_dep */
+    l = next;
   }
-  dag_free_children(n);
 }
 
 static void


### PR DESCRIPTION
## Summary
- free `dag_node_add_dep` allocations when nodes finish executing
- clean up docstring in `simulate.py` so tests run

## Testing
- `make check`