### PR TITLE
Add simple NCC compile driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -570,6 +570,9 @@ tar:
 HOSTCC ?= gcc
 HOSTCFLAGS ?= -Wall -Werror -std=c99
 
+tools/ncc: tools/ncc.c tools/compiler_utils.c tools/compiler_utils.h
+	$(HOSTCC) $(HOSTCFLAGS) -o $@ tools/ncc.c tools/compiler_utils.c
+
 src-uland/exo_unit_test: src-uland/exo_unit_test.c
 	$(HOSTCC) $(HOSTCFLAGS) -o $@ $<
 

--- a/tools/compiler_utils.c
+++ b/tools/compiler_utils.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include "compiler_utils.h"
+
+char getsuf(const char *s)
+{
+    const char *p = strrchr(s, '/');
+    if(!p)
+        p = s;
+    else
+        p++;
+    const char *dot = strrchr(p, '.');
+    if(!dot || dot == p || dot[1] == '\0')
+        return 0;
+    return dot[1];
+}
+
+char *setsuf(char *s, char suf)
+{
+    char *dot = strrchr(s, '.');
+    if(dot && dot[1])
+        dot[1] = suf;
+    return s;
+}
+
+char *copy(const char *s)
+{
+    size_t n = strlen(s) + 1;
+    char *p = malloc(n);
+    if(p)
+        memcpy(p, s, n);
+    return p;
+}
+
+int nodup(char *const *list, const char *s)
+{
+    for(; *list; list++)
+        if(strcmp(*list, s) == 0)
+            return 0;
+    return 1;
+}
+
+int callsys(const char *file, char *const argv[])
+{
+    pid_t pid = fork();
+    if(pid == 0){
+        execv(file, argv);
+        perror(file);
+        _exit(1);
+    } else if(pid < 0){
+        perror("fork");
+        return 1;
+    }
+    int status;
+    while(waitpid(pid, &status, 0) < 0);
+    if(WIFSIGNALED(status))
+        return 1;
+    return WEXITSTATUS(status);
+}

--- a/tools/compiler_utils.h
+++ b/tools/compiler_utils.h
@@ -1,0 +1,10 @@
+#ifndef COMPILER_UTILS_H
+#define COMPILER_UTILS_H
+
+char getsuf(const char *s);
+char *setsuf(char *s, char suf);
+char *copy(const char *s);
+int nodup(char *const *list, const char *s);
+int callsys(const char *file, char *const argv[]);
+
+#endif /* COMPILER_UTILS_H */

--- a/tools/ncc.c
+++ b/tools/ncc.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "compiler_utils.h"
+
+int main(int argc, char *argv[])
+{
+    char *clist[50] = {0};
+    char *llist[50] = {0};
+    int nc = 0, nl = 0;
+    int cflag = 0;
+    for(int i = 1; i < argc; i++){
+        if(strcmp(argv[i], "-c") == 0){
+            cflag = 1;
+        } else {
+            char *t = copy(argv[i]);
+            if(getsuf(t) == 'c'){
+                clist[nc++] = t;
+                llist[nl++] = setsuf(t, 'o');
+            } else {
+                if(nodup(llist, t))
+                    llist[nl++] = t;
+            }
+        }
+    }
+
+    for(int i = 0; i < nc; i++){
+        char *av[] = {"gcc", "-c", clist[i], NULL};
+        if(callsys("/usr/bin/gcc", av)){
+            fprintf(stderr, "compile failed: %s\n", clist[i]);
+            return 1;
+        }
+    }
+
+    if(!cflag && nl){
+        int ac = 0;
+        char *av[64];
+        av[ac++] = "gcc";
+        for(int i = 0; i < nl; i++)
+            av[ac++] = llist[i];
+        av[ac++] = NULL;
+        if(callsys("/usr/bin/gcc", av))
+            return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a small compile driver `ncc` modeled after early Unix tools
- share helper functions in `compiler_utils.[ch]`
- build `ncc` with the host compiler via Makefile

## Testing
- `make tools/ncc`
- `make check` *(fails: SyntaxError in tests)*