### PR TITLE
Improve Beatty DAG docs and initializer note

### DIFF
--- a/README
+++ b/README
@@ -357,6 +357,8 @@ runs while the DAG scheduler walks the dependency graph for that family.
 Build with ``make`` and run inside QEMU::
 
     $ beatty_dag_demo
+The demonstration shows how Beatty's weights pick the family and how the
+DAG scheduler respects node priorities when executing that family.
 DRIVER SUPERVISOR
 -----------------
 ``rcrs`` is a small supervisor that keeps user-space drivers running.

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -381,5 +381,14 @@ main(void)
 
 The kernel now ships with a Beatty scheduler implementing an affine runtime. It dispatches multiple cooperating contexts according to irrational weights. Enable it with `beatty_sched_set_tasks` after registering the Beatty exo stream. Typed channels can exchange messages whenever the scheduler yields.
 
-When `beatty_dag_stream_init()` is invoked during boot the Beatty scheduler is chained with the DAG scheduler through a single exo stream. Beatty picks the next task family based on its irrational weights and then defers to the DAG scheduler to run the individual ready nodes. This allows user space runtimes to build dependency graphs while still benefiting from the affine time slicing provided by Beatty. Selecting the combined stream merely requires calling the initializer before submitting DAG nodes.
+When `beatty_dag_stream_init()` is invoked during boot the Beatty scheduler is
+chained with the DAG scheduler through a single exo stream.  Beatty picks the
+next task family according to the weights passed to
+`beatty_sched_set_tasks`.  Each family receives time slices proportional to its
+weight following the irrational Beatty sequence.  After a family is chosen the
+DAG scheduler runs the ready nodes of that family ordered by their integer
+priorities so that more important nodes execute first.  This allows user space
+runtimes to build dependency graphs while still benefiting from the affine time
+slicing provided by Beatty. Selecting the combined stream merely requires
+calling the initializer before submitting DAG nodes.
 

--- a/src-kernel/beatty_dag_stream.c
+++ b/src-kernel/beatty_dag_stream.c
@@ -1,0 +1,20 @@
+#include "types.h"
+#include "defs.h"
+#include "exo_stream.h"
+
+/* Initialize the combined Beatty+DAG stream. Call once during boot
+ * after both schedulers are registered so Beatty can select which DAG
+ * family runs next. */
+void
+beatty_dag_stream_init(void)
+{
+    struct exo_sched_ops *bops = beatty_sched_ops();
+    struct exo_sched_ops *dops = dag_sched_ops();
+
+    /* Chain the DAG scheduler under the Beatty scheduler and activate. */
+    bops->next = dops;
+
+    static struct exo_stream bs;
+    bs.head = bops;
+    exo_stream_register(&bs);
+}


### PR DESCRIPTION
## Summary
- clarify Beatty + DAG scheduling in phoenixkernel docs
- document when to call `beatty_dag_stream_init`
- mention integrated demo in README
- add missing `beatty_dag_stream.c` implementation

## Testing
- `make -n | head`