### PR TITLE
Add stub demos for README references

### DIFF
--- a/src-uland/user/beatty_dag_demo.c
+++ b/src-uland/user/beatty_dag_demo.c
@@ -1,0 +1,72 @@
+#include "types.h"
+#include "user.h"
+#include "math_core.h"
+#include "dag.h"
+#include "libos/sched.h"
+
+static double alpha;
+static double beta;
+static int na = 1;
+static int nb = 1;
+
+struct simple_node {
+    const char *name;
+    struct simple_node *next;
+};
+
+static struct simple_node a1 = {"A1", 0};
+static struct simple_node a2 = {"A2", 0};
+static struct simple_node b1 = {"B1", 0};
+static struct simple_node b2 = {"B2", 0};
+
+static struct simple_node *afam = &a1;
+static struct simple_node *bfam = &b1;
+
+static void run_family(struct simple_node **head) {
+    if (*head) {
+        printf(1, "%s\n", (*head)->name);
+        *head = (*head)->next;
+    }
+}
+
+static void schedule_step(void) {
+    double va = alpha * (double)na;
+    double vb = beta * (double)nb;
+    if ((int)va < (int)vb) {
+        run_family(&afam);
+        na++;
+    } else {
+        run_family(&bfam);
+        nb++;
+    }
+    exo_stream_yield();
+}
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+    alpha = phi();
+    beta = alpha / (alpha - 1.0);
+
+    // build simple DAGs
+    a1.next = &a2;
+    b1.next = &b2;
+
+    dag_sched_init();
+    beatty_sched_init();
+
+    dag_node_init((struct dag_node *)&a1, (exo_cap){0});
+    dag_node_init((struct dag_node *)&a2, (exo_cap){0});
+    dag_node_init((struct dag_node *)&b1, (exo_cap){0});
+    dag_node_init((struct dag_node *)&b2, (exo_cap){0});
+
+    dag_sched_submit((struct dag_node *)&a1);
+    dag_sched_submit((struct dag_node *)&a2);
+    dag_sched_submit((struct dag_node *)&b1);
+    dag_sched_submit((struct dag_node *)&b2);
+
+    printf(1, "beatty_dag_demo start\n");
+    for (int i = 0; i < 4; i++)
+        schedule_step();
+    printf(1, "beatty_dag_demo done\n");
+    exit();
+}

--- a/src-uland/user/chan_beatty_rcrs_demo.c
+++ b/src-uland/user/chan_beatty_rcrs_demo.c
@@ -1,0 +1,66 @@
+#include "types.h"
+#include "user.h"
+#include "chan.h"
+#include "math_core.h"
+#include "libos/driver.h"
+#include "proto/driver.capnp.h"
+
+CHAN_DECLARE(ping_chan, DriverPing);
+
+static ping_chan_t *c;
+static double alpha;
+static double beta;
+static int na = 1;
+static int nb = 1;
+static int child;
+
+static void send_task(int slice) {
+    DriverPing m = { .value = slice };
+    exo_cap cap = {0};
+    ping_chan_send(c, cap, &m);
+    printf(1, "sent %d\n", slice);
+}
+
+static void recv_task(void) {
+    DriverPing out = {0};
+    exo_cap cap = {0};
+    ping_chan_recv(c, cap, &out);
+    printf(1, "received %d\n", out.value);
+}
+
+static void schedule_step(int slice) {
+    double va = alpha * (double)na;
+    double vb = beta * (double)nb;
+    if ((int)va < (int)vb) {
+        send_task(slice);
+        na++;
+    } else {
+        recv_task();
+        nb++;
+    }
+}
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+    char *rargv[] = {"typed_chan_recv", 0};
+    child = driver_spawn("typed_chan_recv", rargv);
+
+    c = ping_chan_create();
+    alpha = phi();
+    beta = alpha / (alpha - 1.0);
+
+    for (int i = 1; i <= 4; i++) {
+        if (i == 3) {
+            printf(1, "simulating rcrs restart\n");
+            kill(child);
+            wait();
+            child = driver_spawn("typed_chan_recv", rargv);
+        }
+        schedule_step(i);
+    }
+
+    kill(child);
+    wait();
+    ping_chan_destroy(c);
+    exit();
+}

--- a/src-uland/user/libos_posix_extra_test.c
+++ b/src-uland/user/libos_posix_extra_test.c
@@ -1,0 +1,15 @@
+#include "libos/posix.h"
+#include "user.h"
+
+int main(void) {
+    int fd = libos_open("extra", 0);
+    if (fd < 0)
+        fd = libos_open("extra", O_CREATE);
+    libos_write(fd, "x", 1);
+    libos_close(fd);
+    char *argv[] = {"echo", "extra", 0};
+    libos_spawn("echo", argv);
+    wait();
+    printf(1, "libos_posix_extra_test done\n");
+    exit();
+}

--- a/src-uland/user/qspin_demo.c
+++ b/src-uland/user/qspin_demo.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include "qspinlock.h"
+
+struct spinlock demo_lock;
+
+void qspin_lock(struct spinlock *lk) { (void)lk; printf("qspin_lock called\n"); }
+void qspin_unlock(struct spinlock *lk) { (void)lk; printf("qspin_unlock called\n"); }
+int qspin_trylock(struct spinlock *lk) { (void)lk; printf("qspin_trylock called\n"); return 1; }
+
+int main(void) {
+    if (qspin_trylock(&demo_lock)) {
+        qspin_unlock(&demo_lock);
+    }
+    qspin_lock(&demo_lock);
+    qspin_unlock(&demo_lock);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `beatty_dag_demo` showcase with Beatty and DAG schedulers
- add `chan_beatty_rcrs_demo` for typed channels with Beatty and restart logic
- provide small `qspin_demo` and extra POSIX test stubs

## Testing
- `make -k` *(fails: types.h missing)*
- `make check` *(fails: syntax error in tests)*