### PR TITLE
Add flow PID procfs interface

### DIFF
--- a/README
+++ b/README
@@ -450,3 +450,21 @@ $ python3 scripts/simulate.py
 
 Further work items related to the STREAMS prototype are tracked in
 `TODO_STREAMS.md`.
+
+STREAMS FLOW CONTROL PROCFS
+---------------------------
+The adaptive PID loop used by the STREAMS prototype reads its tuning
+constants from files under ``/proc/streams/fc/``. Three entries hold
+the numeric values::
+
+    /proc/streams/fc/Kp
+    /proc/streams/fc/Ki
+    /proc/streams/fc/Kd
+
+Missing or malformed files fall back to built-in defaults. Writing a
+new value to one of these files immediately updates the active
+constant. The ``flow_pid.py`` helpers ``set_kp()``, ``set_ki()`` and
+``set_kd()`` provide a convenient API for adjusting the parameters.
+
+For testing the base directory can be overridden with the environment
+variable ``FLOW_PID_DIR``.

--- a/flow_pid.py
+++ b/flow_pid.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+PID_DIR = Path(os.environ.get("FLOW_PID_DIR", "/proc/streams/fc"))
+
+# Default PID controller constants
+constants = {
+    "Kp": 1.0,
+    "Ki": 0.0,
+    "Kd": 0.0,
+}
+
+
+def _read_value(name: str, default: float) -> float:
+    path = PID_DIR / name
+    try:
+        return float(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return default
+
+
+def _write_value(name: str, value: float) -> None:
+    PID_DIR.mkdir(parents=True, exist_ok=True)
+    (PID_DIR / name).write_text(f"{value}\n")
+
+
+def flow_pid_init() -> None:
+    """Initialise PID constants from procfs entries."""
+    for key in constants:
+        constants[key] = _read_value(key, constants[key])
+
+
+def set_kp(value: float) -> None:
+    constants["Kp"] = float(value)
+    _write_value("Kp", constants["Kp"])
+
+
+def set_ki(value: float) -> None:
+    constants["Ki"] = float(value)
+    _write_value("Ki", constants["Ki"])
+
+
+def set_kd(value: float) -> None:
+    constants["Kd"] = float(value)
+    _write_value("Kd", constants["Kd"])

--- a/tests/test_flow_pid.py
+++ b/tests/test_flow_pid.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import importlib
+
+import flow_pid
+
+
+def test_flow_pid_init_and_update(tmp_path, monkeypatch):
+    pid_dir = tmp_path / "proc" / "streams" / "fc"
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "Kp").write_text("1.5\n")
+    (pid_dir / "Ki").write_text("0.1\n")
+    (pid_dir / "Kd").write_text("0.05\n")
+
+    monkeypatch.setenv("FLOW_PID_DIR", str(pid_dir))
+
+    importlib.reload(flow_pid)
+
+    flow_pid.flow_pid_init()
+
+    assert flow_pid.constants["Kp"] == 1.5
+    assert flow_pid.constants["Ki"] == 0.1
+    assert flow_pid.constants["Kd"] == 0.05
+
+    flow_pid.set_kp(2.0)
+    assert float((pid_dir / "Kp").read_text().strip()) == 2.0


### PR DESCRIPTION
## Summary
- implement flow PID constants loader with simple procfs-like backing
- expose helpers to update constants on write
- test flow PID loading and updates
- document new procfs interface in README

## Testing
- `pytest tests/test_flow_pid.py -q`
- `pre-commit run --files flow_pid.py tests/test_flow_pid.py README` *(fails: `pre-commit: command not found`)*